### PR TITLE
Fix lsb-release on gentoo.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -309,6 +309,7 @@ detectdistro () {
 				fi
 			fi
 			if [ "$distro_detect" == "Fedora" ]; then distro="Fedora"; fi
+			if [ "$distro_detect" == "Gentoo" ]; then distro="Gentoo"; fi
 			if [ "$distro_detect" == "CrunchBang" ]; then distro="CrunchBang"; fi
 			if [ "$distro_detect" == "Ubuntu" ]; then distro="Ubuntu"; fi
 			if [ "$distro_detect" == "frugalware" ]; then


### PR DESCRIPTION
The same problem will exist for other distro's that do not set `$distro` before settings `$distro_more` when they have lsb-release installed.
