### PR TITLE
xmonad-i386 detected as i3

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -38,7 +38,7 @@ display_type="ASCII"
 
 # WM & DE process names
 # Removed WM's: compiz
-wmnames="fluxbox openbox blackbox xfwm4 metacity kwin icewm pekwm fvwm dwm awesome wmaker stumpwm xmonad musca i3 ratpoison scrotwm spectrwm wmfs wmii beryl subtle e16 enlightenment sawfish emerald monsterwm dminiwm compiz Finder"
+wmnames="fluxbox openbox blackbox xfwm4 metacity kwin icewm pekwm fvwm dwm awesome wmaker stumpwm musca i3 xmonad ratpoison scrotwm spectrwm wmfs wmii beryl subtle e16 enlightenment sawfish emerald monsterwm dminiwm compiz Finder"
 denames="gnome-session xfce-mcs-manage xfce4-session xfconfd ksmserver lxsession gnome-settings-daemon mate-session mate-settings-daemon Finder"
 
 # Export theme settings


### PR DESCRIPTION
Swap order of ‘i3’ and ‘xmonad’ in the WM list to prevent the result of ‘i3’ where xmonad process name is something along the lines of ‘xmonad-i386-bin’. It's a simple swap around of names and most likely not the best solution.
