### PR TITLE
fixed BSDs ram detection and output; dropped some unformatted output

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -368,10 +368,10 @@ detectdistro () {
 			if [ -f /etc/mandriva-release ]; then distro="Mandriva"; fi
 			if [ -f /etc/crunchbang-lsb-release ]; then distro="CrunchBang"; fi
 			if [ -f /etc/gentoo-release ]; then distro="Gentoo"; fi
-			if [ -f /var/run/dmesg.boot ] && grep -om 1 "FreeBSD" /var/run/dmesg.boot; then distro="FreeBSD"; fi 
-			if [ -f /var/run/dmesg.boot ] && grep -om 1 "DragonFly" /var/run/dmesg.boot; then distro="DragonFlyBSD"; fi
-			if [ -f /var/run/dmesg.boot ] && grep -o "OpenBSD" /var/run/dmesg.boot; then distro="OpenBSD"; fi
-			if [ -f /var/run/dmesg.boot ] && grep -o "NetBSD" /var/run/dmesg.boot; then distro="NetBSD"; fi
+			if [ -f /var/run/dmesg.boot ] && grep -om 1 "FreeBSD" /var/run/dmesg.boot 1>/dev/null; then distro="FreeBSD"; fi 
+			if [ -f /var/run/dmesg.boot ] && grep -om 1 "DragonFly" /var/run/dmesg.boot 1>/dev/null; then distro="DragonFlyBSD"; fi
+			if [ -f /var/run/dmesg.boot ] && grep -o "OpenBSD" /var/run/dmesg.boot 1>/dev/null; then distro="OpenBSD"; fi
+			if [ -f /var/run/dmesg.boot ] && grep -o "NetBSD" /var/run/dmesg.boot 1>/dev/null; then distro="NetBSD"; fi
 			if [ -f /usr/share/doc/tc/release.txt ]; then distro="TinyCore"; fi
 			if [ -f /etc/frugalware-release ]; then distro="Frugalware"; fi
 			if [ -f /etc/issue ]; then


### PR DESCRIPTION
Memory detection on BSD systems was totally broken due to wrong variable names (but the computation was right), so I managed to fix this issue. 
Moreover the RAM entry was not at all displayed for FreeBSD, so I've added the missing entry alongside the logo.
There was also a $myram usage rather than $mymem.

The other minor issue was related to BSD distro detection where the grep output was not properly dropped, causing the distro name to appear to the top of the well formatted output. I managed to fix also this one.
