### PR TITLE
Fixed FreeBSD uptime detection ( Issue #36 )

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -555,6 +555,8 @@ detectuptime () {
 		uptime=$(($now-$boot))
 	elif [ "$distro" == "FreeBSD" ]; then
 		uptime=`sysctl -n kern.boottime | awk -F' ' '{print $4}' | tr -d ","`
+		now=`date +%s`
+		uptime=$(($now-$uptime))
 	else
 		if [[ -f /proc/uptime ]]; then
 			uptime=$(</proc/uptime)


### PR DESCRIPTION
Hello, the sec param read from kern.boottime have to be subtracted from the current date expressed using seconds (like the script already does for Mac OS X).

You can find some references using man sysctl or looking at /usr/src/sys/sysctl.h.
