### PR TITLE
Fixes #45

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -344,7 +344,7 @@ detectdistro () {
 					distro_codename=null
 					distro_release=null
 				fi
-			elif [[ "${distro_detect}" == "SUSE LINUX" ]]; then
+			elif [[ "${distro_detect}" == "SUSE LINUX" || "${distro_detect}" =~ "openSUSE" ]]; then
 				distro="openSUSE"
 			elif [[ "${distro_detect}" == "ParabolaGNU/Linux-libre" ]]; then
 				distro="ParabolaGNU/Linux-libre"


### PR DESCRIPTION
The output of `lsb_release -sirc` is different from previous versions of openSUSE, changing from "SUSE LINUX" to "openSUSE project".
Adds a comparation similar to that used for RedHat, more or less explained in a comment in the issue.
