### PR TITLE
fix multi-monitor resolution detection on OS X

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -966,6 +966,9 @@ detectres () {
 		fi
 	elif [[ ${distro} == "Mac OS X" ]]; then
 		xResolution=$(system_profiler SPDisplaysDataType | awk '/Resolution:/ {print $2"x"$4" "}')
+		if [[ "$(echo $xResolution | wc -l)" -ge 1 ]]; then
+			xResolution=$(echo $xResolution | tr "\\n" "," | sed 's/\(.*\),/\1/')
+		fi
 	elif [[ "${distro}" == "Cygwin" ]]; then
 		width=$(wmic desktopmonitor get screenwidth | grep -vE '[a-z]+' | tr -d '\r\n ')
 		height=$(wmic desktopmonitor get screenheight | grep -vE '[a-z]+' | tr -d '\r\n ')


### PR DESCRIPTION
hi, I've fix the multi-monitor resolution detection on OSX.  
by default it's displayed one per line, thus breaking the ASCII Art on the left side. by comparing if there's more than one monitor, I'm able to change that into one-line, without breaking the ASCII :+1:
