### PR TITLE
Fix for Arch Linux ARM on Raspberry Pi

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -425,6 +425,11 @@ detectdistro () {
 				for l in $(echo $distrib_id); do
 					if [[ ${l} =~ ^ID= ]]; then
 						distrib_id=${l//*=}
+						# Quick fix for Arch Linux ARM on Raspberry Pi
+						if [[ $distrib_id == "archarm" ]]; then
+							# Ugly fix - set archarm to arch
+							distrib_id=${distrib_id:0:4}
+						fi
 						break 1
 					fi
 				done


### PR DESCRIPTION
A quick and ugly fix for screenfetch running on Arch Linux ARM @ Raspberry Pi.

ScreenFetch from master branch

```
terry@pi:~$ ./screenfetch
pcilib: Cannot open /proc/bus/pci
lspci: Cannot find any working access method.
                             terry@pi
                             OS: Archarm 
                             Kernel: armv6l Linux 3.10.4-1-ARCH+
         #####               Uptime: 3h 11m
        #######              Packages: Unknown
        ##O#O##              Shell: 606
        #######              Disk: 587M / 4.6G (13%)
      ###########            CPU: ARMv6-compatible processor rev 7 (v6l) @ 700MHz
     #############           RAM: 45MB / 460MB
    ###############         
    ################        
   #################        
 #####################      
 #####################      
   #################        



```

Looking at the code logic, looks like screenfetch is pulling distribution information from `/etc/os-releases`.

On Pi, the contents of the `/etc/os-release` file like below, the key issue is its ID => `archarm`. This file is a part of the [`filesystem`](https://github.com/archlinuxarm/PKGBUILDs/blob/master/core/filesystem/os-release) package.

``` bash
NAME="Arch Linux ARM"
ID=archarm
ID_LIKE=arch
PRETTY_NAME="Arch Linux ARM"
ANSI_COLOR="0;36"
HOME_URL="http://archlinuxarm.org/"
SUPPORT_URL="https://archlinuxarm.org/forum"
BUG_REPORT_URL="https://github.com/archlinuxarm/PKGBUILDs/issues"
```

This commit is a quick and ugly fix, may need a bit more polish when merged;-)

> NOTE: Shell detection is another problem, I'll look into it later if I have time. `lspci` is causing error messages, may also need some code to handle it.

``````
terry@pi:~$ ./screenfetch-dev
pcilib: Cannot open /proc/bus/pci
lspci: Cannot find any working access method.
                   -`
                  .o+`                 terry@pi
                 `ooo/                 OS: Arch Linux 
                `+oooo:                Kernel: armv6l Linux 3.10.4-1-ARCH+
               `+oooooo:               Uptime: 3h 13m
               -+oooooo+:              Packages: 159
             `/:-:++oooo+:             Shell: 606
            `/++++/+++++++:            Disk: 587M / 4.6G (13%)
           `/++++++++++++++:           CPU: ARMv6-compatible processor rev 7 (v6l) @ 700MHz
          `/+++ooooooooooooo/`         RAM: 46MB / 460MB
         ./ooosssso++osssssso+`       
        .oossssso-````/ossssss+`      
       -osssssso.      :ssssssso.     
      :osssssss/        osssso+++.    
     /ossssssss/        +ssssooo/-    
   `/ossssso+/:-        -:/+osssso+-  
  `+sso+:-`                 `.-/+oso: 
 `++:.                           `-/+/
 .`                                 `/
``````
