### PR TITLE
CentOS Art Color Tweak

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2779,15 +2779,9 @@ asciiText () {
                 "CentOS")
                         if [[ "$no_color" != "1" ]]; then
                                 c1=$(getColor 'yellow') # White
-<<<<<<< HEAD
                                 c2=$(getColor 'light green') # White
                                 c3=$(getColor 'light blue') # White
                                 c4=$(getColor 'light purple') # White
-=======
-                                c2=$(getColor 'green') # White
-                                c3=$(getColor 'blue') # White
-                                c4=$(getColor 'purple') # White
->>>>>>> e57e07dc98216651364ccf2b1a856de58b998247
                                 c5=$(getColor 'white') # White
                         fi
                         if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; fi
@@ -2801,13 +2795,8 @@ asciiText () {
 "       ${c2}.4MA.' 'VKK ${c1}LJ${c4} KKV' '.4Mb.       %s"
 "${c4}     . ${c2}KKKKKA.' 'V ${c1}LJ${c4} V' '.4KKKKK ${c3}.     %s"
 "${c4}   .4D ${c2}KKKKKKKA.'' ${c1}LJ${c4} ''.4KKKKKKK ${c3}FA.   %s"
-<<<<<<< HEAD
 "${c4}  +QDD ++++++++++++  ${c3}++++++++++++ GFD+  %s"
 "${c4}   'VD ${c3}KKKKKKKK'.. ${c2}LJ ${c1}..'KKKKKKKK ${c3}FV'   %s"
-=======
-"${c4}  <QDD ++++++++++++  ${c3}++++++++++++ GFD>  %s"
-"${c4}   'VD ${c3}KKKKKKKK'.. ${c2}LJ ${c1}..'KKKKKKKK ${c3}FV    %s"
->>>>>>> e57e07dc98216651364ccf2b1a856de58b998247
 "${c4}     ' ${c3}VKKKKK'. .4 ${c2}LJ ${c1}K. .'KKKKKV ${c3}'     %s"
 "       ${c3} 'VK'. .4KK ${c2}LJ ${c1}KKA. .'KV'        %s"
 "       ${c3}A. . .4KKKK ${c2}LJ ${c1}KKKKA. . .4       %s"


### PR DESCRIPTION
The selected colors seemed to be mixing bold and not bold, even among elements that should be the same color. This diff should fix it.
Before:
![screenshot - 09242013 - 06 45 16 am](https://f.cloud.github.com/assets/2435101/1200235/914dcbde-2521-11e3-8488-82a56f41115e.png)

After:
![screenshot - 09242013 - 07 01 05 am](https://f.cloud.github.com/assets/2435101/1200249/c6e155f4-2521-11e3-9942-fd572890b263.png)

---

Also my branch had even more softening of the Fedora art, which could be elided if desired.
![screenshot - 09242013 - 07 02 24 am](https://f.cloud.github.com/assets/2435101/1200258/f9890d94-2521-11e3-8d88-46ae9af3f622.png)
