### PR TITLE
fixed dual GPU detection formatting

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -812,7 +812,7 @@ detectgpu () {
 		fi
 	elif [[ "${distro}" == "Mac OS X" ]]; then
 		gpu_info=$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {print $2}')
-		gpu_len=$(echo "$gpu" | wc -l | tr -d ' ')
+		gpu_len=$(echo "$gpu_info" | wc -l | tr -d ' ')
 		if [ "$gpu_len" -eq 1 ]; then
 			gpu=$(echo "$gpu_info" | tr -d '\n')
 		else


### PR DESCRIPTION
Just a quick one-liner to fix formatting with dual GPUs on OS X. 
Brought up by tsia: https://github.com/KittyKatt/screenFetch/issues/104
