### PR TITLE
fixed dual GPU detection formatting

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -811,13 +811,7 @@ detectgpu () {
 			gpu_info=$(echo "$gpu_info" | grep "OpenGL vendor string")
 		fi
 	elif [[ "${distro}" == "Mac OS X" ]]; then
-		gpu_info=$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {print $2}')
-		gpu_len=$(echo "$gpu_info" | wc -l | tr -d ' ')
-		if [ "$gpu_len" -eq 1 ]; then
-			gpu=$(echo "$gpu_info" | tr -d '\n')
-		else
-			gpu=$(echo "$gpu_info" | tr '\n' ' / ')
-		fi
+		gpu=$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {print $2}' | awk '{ printf "%s / ", $0 }' | sed -e 's/\/ $//g')
 	elif [[ "${distro}" == "Cygwin" ]]; then
 		gpu=$(wmic path Win32_VideoController get caption)
 		gpu=$(tail -1 <<< ${gpu})


### PR DESCRIPTION
this fixes formatting of dual GPU Systems by removing the newline after each GPU and replacing it with " / "
