### PR TITLE
Windows 8.1

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -3138,7 +3138,7 @@ infoDisplay () {
 				else mydistro=$(echo -e "$labelcolor OS:$textcolor $sysArch $distro $prodVers $buildVers"); fi
 			elif [[ "$distro" == "Cygwin" ]]; then
 				distro=$(wmic os get name | head -2 | tail -1)
-				distro=$(expr match "$distro" '\(Microsoft Windows [A-Za-z0-9]\+\)')
+				distro=$(expr match "$distro" '\(Microsoft Windows [A-Za-z0-9.]\+\)')
 				sysArch=$(wmic os get OSArchitecture | head -2 | tail -1 | tr -d '\r ')
 				mydistro=$(echo -e "$labelcolor OS:$textcolor $distro $sysArch")
 			else


### PR DESCRIPTION
Also fixes a bug where resolution would be displayed as "x" when wmic cannot display the resolution for whatever reason. (screenfetch doesn't list "Resolution:" in this case)
![screenfetch-screenshot](https://f.cloud.github.com/assets/462101/2257461/2bd0ef80-9e1a-11e3-8492-cfe412a1f69f.PNG)
