### PR TITLE
PowerPC CPUs no longer blank in OS X

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -772,7 +772,16 @@ detectpkgs () {
 detectcpu () {
 	REGEXP="-r"
 	if [ "$distro" == "Mac OS X" ]; then 
+		cpu=$(echo $(machine))
+		if [[ $cpu == "ppc750" ]]; then
+			cpu="IBM PowerPC G3"
+		elif [[ $cpu == "ppc7400" || $cpu == "ppc7450" ]]; then
+			cpu="IBM PowerPC G4"
+		elif [[ $cpu == "ppc970" ]]; then
+			cpu="IBM PowerPC G5"
+		else
 		cpu=$(echo $(sysctl -n machdep.cpu.brand_string))
+		fi
 		REGEXP="-E"
 	elif [ "$distro" == "FreeBSD" ]; then cpu=$(sysctl -n hw.model)
 	elif [ "$distro" == "DragonflyBSD" ]; then cpu=$(sysctl -n hw.model)


### PR DESCRIPTION
Instead of showing blank in the CPU section, PowerPC Mac Luddites can now show off their CPUs using screenfetch.
