### PR TITLE
Release parameter for Chakra Linux

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -359,7 +359,7 @@ detectdistro () {
 				fi
 			elif [[ "${distro_detect}" == "Chakra" ]]; then
 				distro="Chakra"
-				distro_release=null
+				distro_release=""
 			elif [[ "${distro_detect}" == "CentOS" ]]; then
 				distro="CentOS"
 			elif [[ "${distro_detect}" == "Debian" ]]; then


### PR DESCRIPTION
looks better if you put "" on release for Chakra Linux, cause if not, it says: "Chakra null Descartes" for example

thx for your work! :D
