### PR TITLE
Fix wm detection (#133)

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1266,7 +1266,7 @@ detectwm () {
 	if [[ ${distro} != "Mac OS X" && ${distro} != "Cygwin" ]]; then
 		if [[ -n ${DISPLAY} ]]; then
 			for each in "${wmnames[@]}"; do
-				PID="$(pgrep -U ${UID} $each)"
+				PID="$(pgrep -U ${UID} "^$each$")"
 				if [ "$PID" ]; then
 					case $each in
 						'2bwm') WM="2bwm";;


### PR DESCRIPTION
The problem was that pgrep searches for any process names that contain the
specified string, instead of exact matches.
