### PR TITLE
Fix and improve the RAM usage on OS X

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -904,29 +904,10 @@ detectmem () {
 	human=1024
 	if [ "$distro" == "Mac OS X" ]; then
 		totalmem=$(echo "$(sysctl -n hw.memsize)"/${human}^2|bc)
- 		usedmem=$(top -l 1 | awk '{
- 			if ($0 ~ /PhysMem/) {
- 				for (x=1; x<=NF; x++) {
- 					if ($x ~ /wired/) {
- 						wired = $(x-1)
- 						gsub(/[^0-9]/,"",wired)
- 					}
-
- 					if ($x ~ /^active/) {
- 						active = $(x-1)
- 						gsub(/[^0-9]/,"",active)
- 					}
-
- 					if ($x ~ /inactive/) {
- 						inactive = $(x-1)
- 						gsub(/[^0-9]/,"",inactive)
- 					}
- 				}
- 				usedmem = wired + active + inactive
- 				print usedmem
- 				exit
- 			}
- 		}')
+		wiredmem=$(vm_stat | grep wired | awk '{ print $4 }' | sed 's/\.//')
+		activemem=$(vm_stat | grep ' active' | awk '{ print $3 }' | sed 's/\.//')
+		compressedmem=$(vm_stat | grep occupied | awk '{ print $5 }' | sed 's/\.//')
+		usedmem=$(((${wiredmem} + ${activemem} + ${compressedmem}) * 4096 / 1024 / 1024))		 		
 	elif [ "$distro" == "Cygwin" ]; then
 		total_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)
 		totalmem=$((${total_mem}/1024))


### PR DESCRIPTION
Previously it only showed the value of the wired memory and due to a bug it did not add the active and inactive memory to the total used memory.

I changed it to use the values from vm_stat and instead of the inactive memory (which acts like a buffer/cache) now the "Compressed Memory" introduced in OS X 10.9 is counted in.
