### PR TITLE
Added option to hide the user and hostname

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -62,6 +62,7 @@ specified on the command line, and those are shown below or by executing `screen
       -N                 Strip all color from output.
       -t                 Truncate output based on terminal width (Experimental!).
       -p                 Output in portrait mode, with logo above info.
+      -H                 Hide user and hostname.
       -s(m)              Using this flag tells the script that you want it
                          to take a screenshot. Use the -m flag if you would like
                          to move it to a new location afterwards.

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -63,7 +63,7 @@ screenshot=
 upload=
 # This setting lest the script know where you would like to upload the file to. Valid hosts are: teknik, mediacrush, pomf, imgur, hmp, and a configurable local.
 uploadLoc=
-# THis setting lets the script know whwther you want to hide the user and host. 1=Hide 0=Show
+# This setting lets the script know whether you want to hide the user and host. 1=Hide 0=Show
 hideUser=
 # You can specify a custom screenshot command here. Just uncomment and edit. Otherwise, we'll be using the default command: scrot -cd3.
 # screenCommand="scrot -cd5"

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -63,6 +63,8 @@ screenshot=
 upload=
 # This setting lest the script know where you would like to upload the file to. Valid hosts are: teknik, mediacrush, pomf, imgur, hmp, and a configurable local.
 uploadLoc=
+# THis setting lets the script know whwther you want to hide the user and host. 1=Hide 0=Show
+hideUser=
 # You can specify a custom screenshot command here. Just uncomment and edit. Otherwise, we'll be using the default command: scrot -cd3.
 # screenCommand="scrot -cd5"
 shotfile=$(printf "screenFetch-`date +'%Y-%m-%d_%H-%M-%S'`.png")
@@ -220,6 +222,7 @@ displayHelp() {
 	printf "   ${bold}-N${c0}                 Strip all color from output.\n"
 	printf "   ${bold}-t${c0}                 Truncate output based on terminal width (Experimental!).\n"
 	printf "   ${bold}-p${c0}                 Portrait output.\n"
+	printf "   ${bold}-H${c0}                 Hide user and hostname.\n"
 	printf "   ${bold}-s(u)${c0}              Using this flag tells the script that you want it\n"
 	printf "		      to take a screenshot. Use the -u flag if you would like\n"
 	printf "		      to upload the screenshots to one of the pre-configured\n"
@@ -260,7 +263,7 @@ case $1 in
 esac
 		
 
-while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:p" flags; do
+while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:p:H" flags; do
 	case $flags in
 		h) displayHelp; exit 0;;
 		s) screenshot='1' ;;
@@ -278,6 +281,7 @@ while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:p" flags; do
 		d) overrideDisplay="${OPTARG}" ;;
 		N) no_color='1';;
 		p) portraitSet='Yes' ;;
+		H) hideUser='1' ;;
 		:) errorOut "Error: You're missing an argument somewhere. Exiting."; exit 1;;
 		?) errorOut "Error: Invalid flag somewhere. Exiting."; exit 1;;
 		*) errorOut "Error"; exit 1;;
@@ -666,10 +670,15 @@ detectdistro () {
 
 # Host and User detection - Begin
 detecthost () {
-	myUser=${USER}
-	myHost=${HOSTNAME}
-	if [[ "${distro}" == "Mac OS X" ]]; then myHost=${myHost/.local}; fi
-	verboseOut "Finding hostname and user...found as '${myUser}@${myHost}'"
+	if [[ "$hideUser" != "1" ]]; then
+		myUser=${USER}
+		myHost=${HOSTNAME}
+		if [[ "${distro}" == "Mac OS X" ]]; then myHost=${myHost/.local}; fi
+		verboseOut "Finding hostname and user...found as '${myUser}@${myHost}'";
+	else 
+		myUser="anon"
+		myHost="anonymous"
+	fi
 }
 
 # Find Number of Running Processes

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -675,9 +675,6 @@ detecthost () {
 		myHost=${HOSTNAME}
 		if [[ "${distro}" == "Mac OS X" ]]; then myHost=${myHost/.local}; fi
 		verboseOut "Finding hostname and user...found as '${myUser}@${myHost}'";
-	else 
-		myUser="anon"
-		myHost="anonymous"
 	fi
 }
 
@@ -3402,7 +3399,15 @@ infoDisplay () {
 		mygpu=$(echo -e "$labelcolor GPU:$textcolor $cpu"); out_array=( "${out_array[@]}" "$mygpu" )
 		mymem=$(echo -e "$labelcolor RAM:$textcolor $mem"); out_array=( "${out_array[@]}" "$mymem" )
 	else
-		if [[ "${display[@]}" =~ "host" ]]; then myinfo=$(echo -e "${labelcolor}${myUser}$textcolor${bold}@${c0}${labelcolor}${myHost}"); out_array=( "${out_array[@]}" "$myinfo" ); ((display_index++)); fi
+		if [[ "${display[@]}" =~ "host" ]]; then
+			if [[ "$hideUser" != "1" ]]; then 
+				myinfo=$(echo -e "${labelcolor}${myUser}$textcolor${bold}@${c0}${labelcolor}${myHost}");
+			else 
+				myinfo="";
+			fi
+			out_array=( "${out_array[@]}" "$myinfo" );
+			((display_index++));
+		fi
 		if [[ "${display[@]}" =~ "distro" ]]; then
 			if [ "$distro" == "Mac OS X" ]; then
 				sysArch=`str1=$(ioreg -l -p IODeviceTree | grep firmware-abi);echo ${str1: -4: 2}bit`


### PR DESCRIPTION
It's often not beneficial to show the user and hostname when uploading screenshots to puplic image boards, so I added the option to hide the user and hostname with the '-H' flag. For now it's replaced with 'anon' and 'anonymous', but maybe a better substitution is '****' or maybe even remove the line completely?