### PR TITLE
Combine GTK 2/3 themes if they are the same (Closes #163)

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -3462,7 +3462,11 @@ infoDisplay () {
 						mygtk2=$(echo -e "$labelcolor GTK2 Theme:$textcolor $gtk2Theme"); out_array=( "${out_array[@]}" "$mygtk2" ); ((display_index++))
 						mygtk3=$(echo -e "$labelcolor GTK3 Theme:$textcolor $gtk3Theme"); out_array=( "${out_array[@]}" "$mygtk3" ); ((display_index++))
 					else
-						mygtk=$(echo -e "$labelcolor GTK Theme:$textcolor ${mygtk2}${mygtk3}"); out_array=( "${out_array[@]}" "$mygtk" ); ((display_index++))
+                        if [[ "$gtk2Theme" == "$gtk3Theme" ]]; then
+                            mygtk=$(echo -e "$labelcolor GTK Theme:$textcolor ${gtk2Theme} [GTK2/3]"); out_array=( "${out_array[@]}" "$mygtk" ); ((display_index++))
+                        else
+                            mygtk=$(echo -e "$labelcolor GTK Theme:$textcolor ${mygtk2}${mygtk3}"); out_array=( "${out_array[@]}" "$mygtk" ); ((display_index++))
+                        fi
 					fi
 					if [[ "$gtkIcons" != "Not Applicable" || "$gtkIcons" != "Not Found" ]]; then
 						if [ -n "$gtkIcons" ]; then 


### PR DESCRIPTION
Works on my test boxes, giving something along the lines of `GTK Theme: oxygen-gtk [GTK2/3]`. It may need still some more testing for specific setups. Closes #163.
