### PR TITLE
Add an option to supply custom ASCII art.

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -70,6 +70,11 @@ specified on the command line, and those are shown below or by executing `screen
                          ASCII logo colors and the label colors. The second argument
                          controls the colors of the information found. One argument may be
                          used without the other.
+      -a 'PATH'          You can specify a custom ASCII art by passing the path
+                         to a Bash script, defining `startline` and `fulloutput`
+                         variables, and optionally `labelcolor` and `textcolor`.
+                         See the `asciiText` function in the source code for more
+                         informations on the variables format.
       -S 'COMMAND'       Here you can specify a custom screenshot command for
                          the script to execute. Surrounding quotes are required.
       -D 'DISTRO'        Here you can specify your distribution for the script

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -262,7 +262,7 @@ case $1 in
 esac
 		
 
-while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:p" flags; do
+while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:pa:" flags; do
 	case $flags in
 		h) displayHelp; exit 0;;
 		s) screenshot='1' ;;
@@ -280,6 +280,7 @@ while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:p" flags; do
 		d) overrideDisplay="${OPTARG}" ;;
 		N) no_color='1';;
 		p) portraitSet='Yes' ;;
+		a) art="${OPTARG}" ;;
 		:) errorOut "Error: You're missing an argument somewhere. Exiting."; exit 1;;
 		?) errorOut "Error: Invalid flag somewhere. Exiting."; exit 1;;
 		*) errorOut "Error"; exit 1;;
@@ -1895,8 +1896,10 @@ asciiText () {
 # Distro logos and ASCII outputs
 	if [[ "$fake_distro" ]]; then distro="${fake_distro}"; fi
 	if [[ "$asc_distro" ]]; then myascii="${asc_distro}"
+	elif [[ "$art" ]]; then myascii="custom"
 	else myascii="${distro}"; fi
 	case ${myascii} in
+		"custom") source "$art" ;;
 		"Arch Linux - Old")
 			if [[ "$no_color" != "1" ]]; then
 				c1=$(getColor 'white') # White
@@ -3379,6 +3382,7 @@ infoDisplay () {
 		"CentOS"|"Ubuntu"|*) labelcolor=$(getColor 'yellow');;
 	esac
 	[[ "$my_lcolor" ]] && labelcolor="${my_lcolor}"
+	if [[ "$art" ]]; then source "$art"; fi
 	if [[ "$no_color" == "1" ]]; then labelcolor=""; bold=""; c0=""; textcolor=""; fi
 	# Some verbosity stuff
 	[[ "$screenshot" == "1" ]] && verboseOut "Screenshot will be taken after info is displayed."

--- a/screenfetch.1
+++ b/screenfetch.1
@@ -80,6 +80,12 @@ ASCII logo colors and the label colors. The second argument
 controls the colors of the information found. One argument may be
 used without the other.
 .TP
+.B \-a 'PATH'
+You can specify a custom ASCII art by passing the path to a Bash script,
+defining \fBstartline\fR and \fBfulloutput\fR variables, and optionally
+\fBlabelcolor\fR and \fBtextcolor\fR. See the \fBasciiText\fR function
+in the source code for more informations on the variables format.
+.TP
 .B \-S 'COMMAND'
 Here you can specify a custom screenshot command for
 the script to execute. Surrounding quotes are required.


### PR DESCRIPTION
Hello there,

I once wanted to display a custom ASCII art next to the screenFetch informations, and I ended up adding it as a "distro" in the source code, and selecting it with the `-A` option to get my custom logo.

While it was sufficient, I thought It would be slightly better to have an option to specify a custom ASCII art.

With this PR, we can give the `-a` option a path to a Bash script, defining the `startline` and `fulloutput` variables, and optionally `labelcolor` and `textcolor`.

This way, it's easy to use a custom logo without having to change the source code.

Here's an example "art file":

``` bash
c1=$(getColor yellow)
labelcolor=$c1
startline=1

fulloutput=(
    ''
    "$c1"'            $$$$$$$$$$             %s'
    "$c1"'        $$$$$$$$$$$$$$$$$$        %s'
    "$c1"'      $$$$    $$$$$$    $$$$      %s'
    "$c1"'      $$  $$$$$$$$$$$$$$  $$      %s'
    "$c1"'    $$  $$    $$$$$$    $$  $$    %s'
    "$c1"'    $$  $$    $$$$$$    $$  $$    %s'
    "$c1"'    $$$$$$$$$$$$$$$$$$$$$$$$$$    %s'
    "$c1"'    $$$$$$$$$$$$$$$$$$$$$$$$$$    %s'
    "$c1"'    $$$$$$$$  $$$$$$  $$$$$$$$    %s'
    "$c1"'      $$$$$$$$      $$$$$$$$      %s'
    "$c1"'      $$$$$$$$$$$$$$$$$$$$$$      %s'
    "$c1"'        $$$$$$$$$$$$$$$$$$        %s'
    "$c1"'            $$$$$$$$$$            %s'
    "$c1"'                                  %s'
    "$c1"'                                  %s'
)
```

I don't know if the need for a custom logo option is common enough to merge this into `master`… but I still wanted to propose this change.
