### PR TITLE
fix little bug "[[ ! ]] /usr/bin/screenfetch: line 817: [: 2415.7: integer expression expected"

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -819,7 +819,7 @@ detectcpu () {
 			cpu_mhz=$(awk -F':' '/cpu MHz/{ print int($2+.5) }' /proc/cpuinfo | head -n 1)
 		fi
 		if [ -n "$cpu_mhz" ];then
-			if [ $cpu_mhz -gt 999 ];then
+			if [ $(echo $cpu_mhz | cut -d. -f1) -gt 999 ];then
 				cpu_ghz=$(awk '{print $1/1000}' <<< "${cpu_mhz}")
 				cpu="$cpu @ ${cpu_ghz}GHz"
 			else


### PR DESCRIPTION
before this change an error message was displayed on my installation:

[anakin@DeathStar]$ screenfetch 
[ ! ]] /usr/bin/screenfetch: line 817: [: 2415.7: integer expression expected

 [...]

Now seems work well... :)
