### PR TITLE
remove useless use of cat in grep statement

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1760,7 +1760,7 @@ detectgtk () {
 
 				if [ "$distro" == "Cygwin" -a "$gtkFont" == "Not Found" ]; then
 					if [ -f "$HOME/.minttyrc" ]; then
-						gtkFont="$(cat "$HOME/.minttyrc" | grep '^Font=.*' | grep -o '[0-9A-z ]*$')"
+						gtkFont="$(grep '^Font=.*' "$HOME/.minttyrc" | grep -o '[0-9A-z ]*$')"
 					fi
 				fi
 			;;


### PR DESCRIPTION
Tiny one line change.
Passes file directly into `grep` instead of wasting a process and calling `cat`.