### PR TITLE
Fixed total memory detection on OpenBSD.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -943,7 +943,7 @@ detectmem () {
 		used_mem=$(($round_mem - $avail_mem))
 		usedmem=$(($used_mem / ($human * $human) ))
 	elif [ "$distro" == "OpenBSD" ]; then
-		totalmem=$(top -1 1 | awk '/Real:/ {k=split($3,a,"/");print a[k] }' | tr -d 'M')
+		totalmem=`dmesg | grep 'real mem' | cut -d' ' -f5 | tr -d '()MB'`
 		usedmem=$(top -1 1 | awk '/Real:/ {print $3}' | sed 's/M.*//')
 	elif [ "$distro" == "NetBSD" ]; then
 		phys_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)


### PR DESCRIPTION
On my OpenBSD 5.6 install, screenFetch was printing out an incorrect value for total memory. I changed it so that instead of using top, which apparently doesn't give a reliable number for the total memory of the system, it asks the kernel directly using dmesg.