### PR TITLE
add detection for Sabayon

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -646,6 +646,7 @@ detectdistro () {
 		crunchbang) distro="CrunchBang" ;;
 		gentoo) distro="Gentoo" ;;
 		funtoo) distro="Funtoo" ;;
+		sabayon) distro="Sabayon" ;;
 		slackware) distro="Slackware" ;;
 		frugalware) distro="Frugalware" ;;
 		peppermint) distro="Peppermint" ;;


### PR DESCRIPTION
If we don't add it, Sabayon detection will fail.