### PR TITLE
Readme updates

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -20,7 +20,7 @@ command! This script is very easy to add to and can easily be extended.
 ### Mageia
 
 1. Install screenfetch from the official repositories with urpmi or rpmdrake.
-   e.g. # urpmi screenfetch
+   e.g.: `urpmi screenfetch`
 
 ### Mac
 
@@ -29,7 +29,7 @@ command! This script is very easy to add to and can easily be extended.
 ### Gentoo or Sabayon
 
 1. Emerge screenfetch from portage using `emerge screenfetch`
-2. Sabayon users can install screenfetch from entropy using 'equo install screenfetch'
+2. Sabayon users can install screenfetch from entropy using `equo install screenfetch`
 
 ### Ubuntu (>14.04) and Debian (testing/unstable)
 
@@ -42,7 +42,7 @@ command! This script is very easy to add to and can easily be extended.
 
 ### Others
 
-1. Download the latest source. Found at http://git.silverirc.com/cgit.cgi/screenfetch.git/plain/screenfetch-dev
+1. Download the latest source at https://github.com/KittyKatt/screenFetch
 2. In a terminal, make the file executable by doing the following: `chmod +x /path/to/screenfetch/screenfetch-dev`
 3. Then, either keep it there, or move it to somewhere in your $PATH to make it available without having to use the full path to the script.
 
@@ -86,10 +86,15 @@ specified on the command line, and those are shown below or by executing `screen
       -V, --version      Display current script version.
       -h, --help         Display this help.
 
-
 ## Contact Me
 
 If you would like to suggest something new, inform me of an issue in the
 script, become part of the project, or talk to me about anything else,
 you can either email me at `zeldarealm@gmail.com` or you can connect
-to Rizon and reach me at irc://irc.rizon.net/screenFetch
+to Rizon and reach me at `irc://irc.rizon.net/screenFetch`
+
+## Screenshots
+
+![Screenfetch sample](http://served.kittykatt.us/screens/screenfetch/screenfetch-asciilogos-20120128-1.png)
+
+![Screenfetch sample](http://served.kittykatt.us/screens/screenfetch/screenfetch-asciilogos-20120128-2.png)

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -18,8 +18,8 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Yes, I do realize some of this is horribly ugly coding. Any ideas/suggestions would be
-# appreciated by emailing me or by stopping by http://github.com/KittyKatt/screenFetch . You
-# could also drop in on my IRC network, SilverIRC, at irc://kittykatt.silverirc.com/me0wz
+# appreciated by emailing me or by stopping by http://github.com/KittyKatt/screenFetch. You
+# could also drop in on the IRC channel at irc://irc.rizon.net/screenFetch.
 # to put forth suggestions/ideas. Thank you.
 
 # Requires: bash 4.0+


### PR DESCRIPTION
- Remove references to irc.silverirc.com, replacing it with the new channel (#screenfetch) at rizon (Closes #139).
- Consistently use backticks to format code.
- In README.md, replace links to git.silverirc.com with GitHub.
    - The latter seems to be way more updated (2014-04-30 on silverirc vs 2015-02-19 on GitHub).
- Add some screenshots posted on https://bbs.archlinux.org/viewtopic.php?id=94169 (Closes #149).

edit: Closes #173.