### PR TITLE
Add new raspbian detection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -373,6 +373,8 @@ detectdistro () {
 				else
 					distro="Debian"
 				fi
+			elif [[ "${distro_detect}" == "Raspbian" ]]; then
+				distro="Raspbian"
 			elif [[ "${distro_detect}" == "elementary" || "${distro_detect}" == "elementary OS" ]]; then
 				distro="elementary OS"
 			elif [[ "${distro_detect}" == "EvolveOS" ]]; then


### PR DESCRIPTION
Well, this works for [osmc](https://osmc.tv) alpha 4 which is based on Raspbian jessie.