### PR TITLE
use Ubuntu-3color by default, remove old yellow logo

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2036,7 +2036,7 @@ asciiText () {
 "                               %s")
 		;;
 
-		"Ubuntu-3color")
+		"Ubuntu")
 			if [[ "$no_color" != "1" ]]; then
 				c1=$(getColor 'white') # White
 				c2=$(getColor 'light red') # Light Red
@@ -2062,33 +2062,6 @@ asciiText () {
 "$c2               /osyyyyyyo$c3++ooo+++/    %s"
 "$c2                   \`\`\`\`\` $c3+oo+++o\:    %s"
 "$c3                          \`oo++.      %s")
-		;;
-
-		"Ubuntu")
-			if [[ "$no_color" != "1" ]]; then
-				if [[ $(tput colors) -eq "256" ]]; then c1=$(getColor 'orange') # Orange if 256 support
-				else c1=$(getColor 'yellow'); fi # Bold Yellow
-			fi
-			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; c1="${my_lcolor}"; c1="${my_lcolor}"; fi
-			startline="0"
-			fulloutput=("$c1                          ./+o+-       %s"
-"$c1                  yyyyy- $c1-yyyyyy+     %s"
-"$c1               $c1://+//////$c1-yyyyyyo     %s"
-"$c1           .++ $c1.:/++++++/-$c1.+sss/\`     %s"
-"$c1         .:++o:  $c1/++++++++/:--:/-     %s"
-"$c1        o:+o+:++.$c1\`..\`\`\`.-/oo+++++/    %s"
-"$c1       .:+o:+o/.$c1          \`+sssoo+/   %s"
-"$c1  .++/+:$c1+oo+o:\`$c1             /sssooo.  %s"
-"$c1 /+++//+:$c1\`oo+o$c1               /::--:.  %s"
-"$c1 \+/+o+++$c1\`o++o$c1               ++////.  %s"
-"$c1  .++.o+$c1++oo+:\`$c1             /dddhhh.  %s"
-"$c1       .+.o+oo:.$c1          \`oddhhhh+   %s"
-"$c1        \+.++o+o\`\`-\`\`$c1\`\`.:ohdhhhhh+    %s"
-"$c1         \`:o+++ $c1\`ohhhhhhhhyo++os:     %s"
-"$c1           .o:$c1\`.syhhhhhhh/$c1.oo++o\`     %s"
-"$c1               /osyyyyyyo$c1++ooo+++/    %s"
-"$c1                   \`\`\`\`\` $c1+oo+++o\:    %s"
-"$c1                          \`oo++.      %s")
 		;;
 
 		"Debian")
@@ -3461,11 +3434,11 @@ infoDisplay () {
 		"Arch Linux - Old"|"Fedora"|"Korora"|"Mandriva"|"Mandrake"|"Chakra"|"ChromeOS"|"Sabayon"|"Slackware"|"Mac OS X"|"Trisquel"|"Kali Linux"|"Jiyuu Linux"|"Antergos"|"KaOS") labelcolor=$(getColor 'light blue');;
 		"Arch Linux"|"Frugalware"|"Mageia"|"Deepin") labelcolor=$(getColor 'light cyan');;
 		"Mint"|"LMDE"|"openSUSE"|"LinuxDeepin"|"DragonflyBSD"|"Manjaro"|"Manjaro-tree"|"Android"|"Void") labelcolor=$(getColor 'light green');;
-		"Ubuntu-3color"|"FreeBSD"|"FreeBSD - Old"|"Debian"|"Raspbian"|"BSD"|"Red Hat Enterprise Linux"|"Peppermint"|"Cygwin"|"Fuduntu"|"NetBSD"|"Scientific Linux"|"DragonFlyBSD"|"BackTrack Linux") labelcolor=$(getColor 'light red');;
+		"Ubuntu"|"FreeBSD"|"FreeBSD - Old"|"Debian"|"Raspbian"|"BSD"|"Red Hat Enterprise Linux"|"Peppermint"|"Cygwin"|"Fuduntu"|"NetBSD"|"Scientific Linux"|"DragonFlyBSD"|"BackTrack Linux") labelcolor=$(getColor 'light red');;
 		"CrunchBang"|"SolusOS"|"Viperr"|"elementary"*) labelcolor=$(getColor 'dark grey');;
 		"Gentoo"|"Parabola GNU/Linux-libre"|"Funtoo"|"Funtoo-text") labelcolor=$(getColor 'light purple');;
 		"Haiku") labelcolor=$(getColor 'green');;
-		"CentOS"|"Ubuntu"|*) labelcolor=$(getColor 'yellow');;
+		"CentOS"|*) labelcolor=$(getColor 'yellow');;
 	esac
 	[[ "$my_lcolor" ]] && labelcolor="${my_lcolor}"
 	if [[ "$art" ]]; then source "$art"; fi


### PR DESCRIPTION
It did always default to the old yellow logo for me, so I had to specifically run `screenfetch -A Ubuntu-3color`. I don't think there's any point in keeping the old logo and not defaulting to the 3color version.