### PR TITLE
screenfetch-dev: fix detection for ubuntu

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -925,7 +925,7 @@ detectgpu () {
 			gpu=$(grep "OpenGL renderer string" <<< "${gpu_info}" | cut -d ':' -f2  | sed -n '1h;2,$H;${g;s/\n/,/g;p}')
 			gpu="${gpu:1}"
 			gpu_info=$(grep "OpenGL vendor string" <<< "${gpu_info}")
-		elif [ -n "$(type -p lspci)" && -z "$gpu" ]; then
+		elif [[ -n "$(type -p lspci)" && -z "$gpu" ]]; then
 			gpu_info=$(lspci 2> /dev/null | grep VGA)
 			gpu=$(grep -oE '\[.*\]' <<< "${gpu_info}" | sed 's/\[//;s/\]//' | sed -n '1h;2,$H;${g;s/\n/, /g;p}')
 		fi


### PR DESCRIPTION
We need to fix it. This is how ubuntu complains. 

lee@fluxuntu:~$ screenfetch 
[[ ! ]] /usr/bin/screenfetch: line 928: [: missing `]'

(following ubuntu logo and system info, blabla)