### PR TITLE
Option to display ASCII distribution logo only

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -47,6 +47,8 @@ valid_display=( distro host kernel uptime pkgs shell res de wm wmtheme gtk disk 
 display=( distro host kernel uptime pkgs shell res de wm wmtheme gtk cpu gpu mem )
 # Display Type: ASCII or Text
 display_type="ASCII"
+# Plain logo
+display_logo="no"
 
 # Colors to use for the information found. These are set below according to distribution. If you would like to set your OWN color scheme for these, uncomment the lines below and edit them to your heart's content.
 # textcolor="\e[0m"
@@ -218,6 +220,7 @@ displayHelp() {
 	printf "		      may be used in conjunction by placing a ; between them as so:\n"
 	printf "		      +var,var,var;-var,var.\n"
 	printf "   ${bold}-n${c0}                 Do not display ASCII distribution logo.\n"
+	printf "   ${bold}-L${c0}                 Display ASCII distribution logo only.\n"
 	printf "   ${bold}-N${c0}                 Strip all color from output.\n"
 	printf "   ${bold}-t${c0}                 Truncate output based on terminal width (Experimental!).\n"
 	printf "   ${bold}-p${c0}                 Portrait output.\n"
@@ -266,7 +269,7 @@ case $1 in
 esac
 		
 
-while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:pa:" flags; do
+while getopts ":hsu:evVEnLNtlS:A:D:o:Bc:d:pa:" flags; do
 	case $flags in
 		h) displayHelp; exit 0 ;;
 		s) screenshot='1' ;;
@@ -279,6 +282,7 @@ while getopts ":hsu:evVEnNtlS:A:D:o:Bc:d:pa:" flags; do
 		A) asc_distro="${OPTARG}" ;;
 		t) truncateSet='Yes' ;;
 		n) display_type='Text' ;;
+		L) display_type='ASCII'; display_logo='Yes' ;;
 		o) overrideOpts="${OPTARG}" ;;
 		c) detectColors "${OPTARGS}" ;;
 		d) overrideDisplay="${OPTARG}" ;;
@@ -3619,6 +3623,11 @@ asciiText () {
 			printf "%s\n" "${out_array}"
             		unset out_array[0]
 			out_array=( "${out_array[@]}" )
+		done
+
+	elif [[ "$display_logo" == "Yes" ]]; then
+		for ((i=0; i<${#fulloutput[*]}; i++)); do
+			printf "${fulloutput[i]}\n"
 		done
 
 	else

--- a/screenfetch.1
+++ b/screenfetch.1
@@ -60,6 +60,9 @@ statements may be used in conjunction by placing a ; between them as so:
 .B \-n
 Do not display ASCII distribution logo.
 .TP
+.B \-L
+Display ASCII distribution logo only.
+.TP
 .B \-N
 Strip all color from output.
 .TP


### PR DESCRIPTION
Now you can do evil things like `screenfetch-dev -L && inxi -Fxz`.
Overriding works too: `screenfetch-dev -L -A Debian`
