### PR TITLE
Detection for the Lumina Desktop Environment

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1249,6 +1249,9 @@ detectde () {
 						KDE)
 							DE=KDE;
 							;;
+						LUMINA)
+							DE=Lumina;
+							;;
 						LXDE)
 							DE=LXDE;
 							;;
@@ -1282,6 +1285,9 @@ detectde () {
 						gnome)
 							DE=Gnome;
 							;;
+						LUMINA)
+							DE=Lumina;
+							;;
 						LXDE|Lubuntu)
 							DE=LXDE;
 							;;
@@ -1296,6 +1302,18 @@ detectde () {
 							;;
 						Cinnamon)
 							DE=Cinnamon
+							;;
+					esac
+				fi
+
+				if [ x"$GDMSESSION" = x"" ]; then
+					# fallback to checking $GDMSESSION
+					case "$GDMSESSION" in
+						Lumina*|LUMINA*|lumina*)
+							DE=Lumina
+							;;
+						MATE|mate)
+							DE=MATE
 							;;
 					esac
 				fi


### PR DESCRIPTION
Lightweight desktop environment using FluxBox wm: https://github.com/pcbsd/lumina

`echo $GDMSESSION` returns `mate` when I'm running MATE and `Lumina-DE` for Lumina.

edit:
The version can now be obtained with `Lumina-DE --version`. (https://github.com/pcbsd/lumina/commit/02e77b6616ababd187543cd80418a39bd2ba6ea0)