### PR TITLE
NixOS detection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -189,7 +189,7 @@ detectColors() {
 	my_hcolor=$(colorNumberToCode "${my_hcolor}")
 }
 
-supported_distros="Antergos, Arch Linux (Old and Current Logos), BLAG, CentOS, Chakra, Chapeau, CrunchBang, Debian, Deepin, Dragora, elementary OS, Evolve OS, Fedora, Frugalware, Fuduntu, Funtoo, Gentoo, gNewSense, Jiyuu Linux, Kali Linux, KaOS, Korora, LinuxDeepin, Linux Mint, LMDE, Logos, Mageia, Mandriva/Mandrake, Manjaro, openSUSE, Parabola GNU/Linux-libre, PeppermintOS, Raspbian, Red Hat Enterprise Linux, Sabayon, Scientific Linux, Slackware, SolusOS, TinyCore, Trisquel, Ubuntu, Viperr and Void."
+supported_distros="Antergos, Arch Linux (Old and Current Logos), BLAG, CentOS, Chakra, Chapeau, CrunchBang, Debian, Deepin, Dragora, elementary OS, Evolve OS, Fedora, Frugalware, Fuduntu, Funtoo, Gentoo, gNewSense, Jiyuu Linux, Kali Linux, KaOS, Korora, LinuxDeepin, Linux Mint, LMDE, Logos, Mageia, Mandriva/Mandrake, Manjaro, NixOS, openSUSE, Parabola GNU/Linux-libre, PeppermintOS, Raspbian, Red Hat Enterprise Linux, Sabayon, Scientific Linux, Slackware, SolusOS, TinyCore, Trisquel, Ubuntu, Viperr and Void."
 supported_other="Dragonfly/Free/Open/Net BSD, Haiku, Mac OS X and Windows+Cygwin."
 supported_dms="KDE, Gnome, Unity, Xfce, LXDE, Cinnamon, MATE, CDE and RazorQt."
 supported_wms="2bwm, Awesome, Beryl, Blackbox, Cinnamon, Compiz, dminiwm, dwm, dtwm, E16, E17, echinus, Emerald, FluxBox, FVWM, herbstluftwm, IceWM, KWin, Metacity, monsterwm, Musca, Gala, Mutter, Muffin, Notion, OpenBox, PekWM, Ratpoison, Sawfish, ScrotWM, SpectrWM, StumpWM, subtle, WindowMaker, WMFS, wmii, Xfwm4, XMonad and i3."
@@ -455,6 +455,9 @@ detectdistro () {
 				"ManjaroLinux")
 					distro="Manjaro"
 					;;
+				"NixOS")
+					distro="NixOS"
+					;;
 				"LinuxMint")
 					distro="Mint"
 					if [[ "${distro_codename}" == "debian" ]]; then
@@ -601,6 +604,7 @@ detectdistro () {
 					elif [ -f /etc/mageia-release ]; then distro="Mageia"
 					elif [ -f /etc/mandrake-release ]; then distro="Mandrake"
 					elif [ -f /etc/mandriva-release ]; then distro="Mandriva"
+					elif [ -f /etc/NIXOS ]; then distro="NixOS"
 					elif [ -f /etc/SuSE-release ]; then distro="openSUSE"
 					elif [ -f /etc/redhat-release ] && grep -q "Red Hat" /etc/redhat-release; then distro="Red Hat Enterprise Linux"
 					elif [ -f /etc/redhat-release ] && grep -q "CentOS" /etc/redhat-release; then distro="CentOS"
@@ -637,6 +641,7 @@ detectdistro () {
 					fi
 				fi
 			fi
+
 			if [[ "${distro}" == "Unknown" ]] && [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" ]]; then
 				if [[ -f /etc/issue ]]; then
 					distro=$(awk 'BEGIN {
@@ -660,6 +665,7 @@ detectdistro () {
 					}' /etc/issue)
 				fi
 			fi
+
 			if [[ "${distro}" == "Unknown" ]] && [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" ]]; then
 				if [[ -f /etc/system-release ]]; then
 					if grep -q "Scientific Linux" /etc/system-release; then
@@ -667,11 +673,15 @@ detectdistro () {
 					fi
 				fi
 			fi
-
-
-
 		fi
 	fi
+
+	# NixOS
+	if type -p nixos-version >/dev/null 2>&1; then
+		distro="NixOS"
+		distro_more="NixOS $(nixos-version)"
+	fi
+
 	if [[ "${distro}" != "Haiku" ]]; then
 		if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
 			if [[ ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -gt 1 ]] || [[ ${BASH_VERSINFO[0]} -gt 4 ]]; then
@@ -683,6 +693,7 @@ detectdistro () {
 			distro="$(tr '[:upper:]' '[:lower:]' <<< ${distro})"
 		fi
 	fi
+
 	case $distro in
 		antergos) distro="Antergos" ;;
 		arch*linux*old) distro="Arch Linux - Old" ;;
@@ -699,6 +710,7 @@ detectdistro () {
 		mandriva) distro="Mandriva" ;;
 		mandrake) distro="Mandrake" ;;
 		mint) distro="Mint" ;;
+		nix|nix*os) distro="NixOS" ;;
 		kali*linux) distro="Kali Linux" ;;
 		lmde) distro="LMDE" ;;
 		opensuse) distro="openSUSE" ;;
@@ -809,6 +821,7 @@ detectpkgs () {
 		'Fuduntu'|'Ubuntu'|'Mint'|'SolusOS'|'Debian'|'Raspbian'|'LMDE'|'CrunchBang'|'Peppermint'|'LinuxDeepin'|'Deepin'|'Kali Linux'|'Trisquel'|'elementary OS'|'gNewSense') pkgs=$(dpkg --get-selections | grep -v deinstall$ | wc -l) ;;
 		'Slackware') pkgs=$(ls -1 /var/log/packages | wc -l) ;;
 		'Gentoo'|'Sabayon'|'Funtoo') pkgs=$(ls -d /var/db/pkg/*/* | wc -l) ;;
+		'NixOS') pkgs=$(ls -d /nix/store/*/ | wc -l) ;;
 		'Fedora'|'Korora'|'BLAG'|'Chapeau'|'openSUSE'|'Red Hat Enterprise Linux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Viperr') pkgs=$(rpm -qa | wc -l) ;;
 		'Void') pkgs=$(xbps-query -l|wc -l);;
 		'Evolve OS') pkgs=$(pisi list-installed | wc -l);;
@@ -3548,6 +3561,35 @@ asciiText () {
 "${c1}                -~\"|{*l}*|\"\"~                  %s")
 		;;
 
+		"NixOS")
+			if [[ "$no_color" != "1" ]]; then
+				c1=$(getColor 'purple')
+				c2=$(getColor 'light blue')
+			fi
+			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; c2="${my_lcolor}"; fi
+			startline="0"
+			fulloutput=("${c2}                  .:.                   %s"
+"${c2}                  :::                  %s"
+"${c2}          ...     :::      ${c1}.:.         %s"
+"${c2}          ':::::. :::      ${c1}:::         %s"
+"${c1}  ...         ${c2}'::::::      ${c1}:::     ..  %s"
+"${c1}   ::::.       ..${c2}':::::.   ${c1}:::  .::::' %s"
+"${c1}     ''::::..::::''  ${c2}'':::.${c1}::::::''    %s"
+"${c1}       .::::${c2}.${c1}''          ${c2}':${c1}:::'        %s"
+"${c1}    .:::::${c2}:::              ${c1}:::         %s"
+"${c1}  .:::'   ${c2}:::              ${c1}:::  ${c2}..:::  %s"
+"${c1}  ''      ${c2}:::              ${c1}:${c2}.:::::''   %s"
+"${c2}         .:::${c1}:.          ${c2}.:::::'       %s"
+"${c2}     ..::::::${c1}'::::.  ${c2}.:::::''::::..    %s"
+"${c2}   ::::'  :::   ${c1}'::::${c2}':'        ${c2}'::::. %s"
+"${c2}  '''     :::     ${c1}:::::::.         ${c2}''' %s"
+"${c2}          :::     ${c1}:::  ':::::.         %s"
+"${c2}          :::     ${c1}:::      '''         %s"
+"${c2}           '      ${c1}:::                  %s"
+"${c1}                  :::                  %s"
+"${c1}                   '                   %s")
+		;;
+
 		*)
 			if [[ "$no_color" != "1" ]]; then
 				c1=$(getColor 'white') # White
@@ -3687,7 +3729,7 @@ infoDisplay () {
 	myascii="${distro}"
 	[[ "${asc_distro}" ]] && myascii="${asc_distro}"
 	case ${myascii} in
-		"Arch Linux - Old"|"Fedora"|"Korora"|"Chapeau"|"Mandriva"|"Mandrake"|"Chakra"|"ChromeOS"|"Sabayon"|"Slackware"|"Mac OS X"|"Trisquel"|"Kali Linux"|"Jiyuu Linux"|"Antergos"|"KaOS"|"Logos"|"gNewSense") labelcolor=$(getColor 'light blue');;
+		"Arch Linux - Old"|"Fedora"|"Korora"|"Chapeau"|"Mandriva"|"Mandrake"|"Chakra"|"ChromeOS"|"Sabayon"|"Slackware"|"Mac OS X"|"Trisquel"|"Kali Linux"|"Jiyuu Linux"|"Antergos"|"KaOS"|"Logos"|"gNewSense"|"NixOS") labelcolor=$(getColor 'light blue');;
 		"Arch Linux"|"Frugalware"|"Mageia"|"Deepin") labelcolor=$(getColor 'light cyan');;
 		"Mint"|"LMDE"|"openSUSE"|"LinuxDeepin"|"DragonflyBSD"|"Manjaro"|"Manjaro-tree"|"Android"|"Void") labelcolor=$(getColor 'light green');;
 		"Ubuntu"|"FreeBSD"|"FreeBSD - Old"|"Debian"|"Raspbian"|"BSD"|"Red Hat Enterprise Linux"|"Peppermint"|"Cygwin"|"Fuduntu"|"NetBSD"|"Scientific Linux"|"DragonFlyBSD"|"BackTrack Linux") labelcolor=$(getColor 'light red');;


### PR DESCRIPTION
The whole concept of Nix differs a lot from typical package managers. On IRC they told me the term "package" isn't even correct. But if I get it right the closest equivalent to counting all packages on Nix would be to count the directories in /nix/store/.

![nixos](https://cloud.githubusercontent.com/assets/5700937/6917957/d3f2f4b4-d7a9-11e4-8ec0-bae900aed367.png)
