### PR TITLE
Lumina-DE: display version if '--version' is supported

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1405,12 +1405,23 @@ detectde () {
 							fi;
 						done
 					fi
+				elif [[ ${DE} == "Lumina" ]]; then
+					if type -p Lumina-DE.real >/dev/null 2>&1; then
+						lumina="$(type -p Lumina-DE.real)"
+					elif type -p Lumina-DE >/dev/null 2>&1; then
+						lumina="$(type -p Lumina-DE)"
+					fi
+					if [[ x"$lumina" != x ]]; then
+						if grep -e '--version' "$lumina" >/dev/null; then
+							DEver=$("$lumina" --version 2>&1 | tr -d \")
+							DE="${DE} ${DEver}"
+						fi
+					fi
 				elif [[ ${DE} == "MATE" ]]; then
 					if type -p mate-session >/dev/null 2>&1; then
 						DEver=$(mate-session --version)
 						DE="${DE} ${DEver//* }"
 					fi
-
 				elif [[ ${DE} == "Unity" ]]; then
 					if type -p unity >/dev/null 2>&1; then
 						DEver=$(unity --version)


### PR DESCRIPTION
Did work well for me. On Lumina 0.8.2.282 is shows `DE: Lumina` and on the current version is shows `DE: Lumina 0.8.4-devel`.