### PR TITLE
Display non-Tux logo if distro is * and kernel != Linux

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -3654,14 +3654,15 @@ asciiText () {
 		;;
 
 		*)
-			if [[ "$no_color" != "1" ]]; then
-				c1=$(getColor 'white') # White
-				c2=$(getColor 'dark grey') # Light Gray
-				c3=$(getColor 'yellow') # Light Yellow
-			fi
-			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; c2="${my_lcolor}"; c3="${my_lcolor}"; fi
-			startline="0"
-			fulloutput=("                             %s"
+			if [ "$(echo "${kernel}" | grep 'Linux' )" ]; then
+				if [[ "$no_color" != "1" ]]; then
+					c1=$(getColor 'white') # White
+					c2=$(getColor 'dark grey') # Light Gray
+					c3=$(getColor 'yellow') # Light Yellow
+				fi
+				if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; c2="${my_lcolor}"; c3="${my_lcolor}"; fi
+				startline="0"
+				fulloutput=("                             %s"
 "                            %s"
 "                            %s"
 "$c2         #####$c0              %s"
@@ -3679,6 +3680,28 @@ asciiText () {
 "                            %s"
 "                            %s"
 "                            %s")
+			else
+				if [[ "$no_color" != "1" ]]; then
+					c1=$(getColor 'light green') # Light Green
+				fi
+				if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; fi
+				startline="0"
+				fulloutput=("                                             %s"
+   "                                            %s"
+"$c1 UUU     UUU NNN      NNN IIIII XXX     XXXX%s"
+"$c1 UUU     UUU NNNN     NNN  III    XX   xXX  %s"
+"$c1 UUU     UUU NNNNN    NNN  III     XX xXX   %s"
+"$c1 UUU     UUU NNN NN   NNN  III      XXXX    %s"
+"$c1 UUU     UUU NNN  NN  NNN  III      xXX     %s"
+"$c1 UUU     UUU NNN   NN NNN  III     xXXXX    %s"
+"$c1 UUU     UUU NNN    NNNNN  III    xXX  XX   %s"
+"$c1  UUUuuuUUU  NNN     NNNN  III   xXX    XX  %s"
+"$c1    UUUUU    NNN      NNN IIIII xXXx    xXXx%s"
+   "                                            %s"
+   "                                            %s"
+   "                                            %s"
+   "                                            %s")
+			fi
   		;;
 	esac
 


### PR DESCRIPTION
I thought it doesn't make much sense to show the Tux logo if the kernel is not Linux.
```
djcj Downloads $ ./screenfetch-unix -D unkown
                                             djcj@djcj-GF8100-M2-TE
                                             OS: unkown 
 UUU     UUU NNN      NNN IIIII XXX     XXXX Kernel: unkown
 UUU     UUU NNNN     NNN  III    XX   xXX   Uptime: 3h 25m
 UUU     UUU NNNNN    NNN  III     XX xXX    Packages: Unknown
 UUU     UUU NNN NN   NNN  III      XXXX     Shell: bash 4.3.11
 UUU     UUU NNN  NN  NNN  III      xXX      Resolution: 1920x1080
 UUU     UUU NNN   NN NNN  III     xXXXX     DE: MATE 1.8.2
 UUU     UUU NNN    NNNNN  III    xXX  XX    WM: Metacity (Marco)
  UUUuuuUUU  NNN     NNNN  III   xXX    XX   GTK Theme: 'BlueMenta' [GTK2/3]
    UUUUU    NNN      NNN IIIII xXXx    xXXx Icon Theme: Mint-X-Aqua
                                             Font: Ubuntu 12
                                             CPU: AMD Athlon X2 240 @ 2.8GHz
                                             GPU: GeForce 8100 / nForce 720a
                                             RAM: 269MB / 867MB
```