### PR TITLE
GNU/Hurd support

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -596,7 +596,7 @@ detectdistro () {
 			fi
 
 			if [[ "${distro}" == "Unknown" ]]; then
-				if [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" ]]; then
+				if [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" || "${OSTYPE}" == "gnu" ]]; then
 					if [ -f /etc/arch-release ]; then distro="Arch Linux"
 					elif [ -f /etc/chakra-release ]; then distro="Chakra"
 					elif [ -f /etc/crunchbang-lsb-release ]; then distro="CrunchBang"
@@ -665,7 +665,7 @@ detectdistro () {
 				fi
 			fi
 
-			if [[ "${distro}" == "Unknown" ]] && [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" ]]; then
+			if [[ "${distro}" == "Unknown" ]] && [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" || "${OSTYPE}" == "gnu" ]]; then
 				if [[ -f /etc/issue ]]; then
 					distro=$(awk 'BEGIN {
 						distro = "Unknown"
@@ -689,7 +689,7 @@ detectdistro () {
 				fi
 			fi
 
-			if [[ "${distro}" == "Unknown" ]] && [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" ]]; then
+			if [[ "${distro}" == "Unknown" ]] && [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" || "${OSTYPE}" == "gnu" ]]; then
 				if [[ -f /etc/system-release ]]; then
 					if grep -q "Scientific Linux" /etc/system-release; then
 						distro="Scientific Linux"
@@ -892,12 +892,20 @@ detectcpu () {
 		elif [[ $cpu == "ppc970" ]]; then
 			cpu="IBM PowerPC G5"
 		else
-		cpu=$(sysctl -n machdep.cpu.brand_string)
+			cpu=$(sysctl -n machdep.cpu.brand_string)
 		fi
 		REGEXP="-E"
-	elif [ "$distro" == "FreeBSD" ]; then cpu=$(sysctl -n hw.model)
-	elif [ "$distro" == "DragonflyBSD" ]; then cpu=$(sysctl -n hw.model)
-	elif [ "$distro" == "OpenBSD" ]; then cpu=$(sysctl -n hw.model | sed 's/@.*//')
+	elif [ "$OSTYPE" == "gnu" ]; then
+		# no /proc/cpuinfo on GNU/Hurd
+		if [ "$(uname -m | grep 'i*86')" ]; then
+			cpu="Unkown x86"
+		else
+			cpu="Unkown"
+		fi
+	elif [[ "$distro" == "FreeBSD" || "$distro" == "DragonflyBSD" ]]; then
+		cpu=$(sysctl -n hw.model)
+	elif [ "$distro" == "OpenBSD" ]; then
+		cpu=$(sysctl -n hw.model | sed 's/@.*//')
 	elif [ "$distro" == "Haiku" ]; then
 		cpu=$(sysinfo -cpu | grep 'CPU #0' | cut -d'"' -f2 | sed 's/(tm)//; s/Processor//;')
 		cpu_mhz=$(sysinfo -cpu | grep 'running at' | awk 'BEGIN{FS="running at "} { print $2; exit }' | cut -d'M' -f1)
@@ -1139,7 +1147,7 @@ detectshell_ver () {
 }
 detectshell () {
 	if [[ ! "${shell_type}" ]]; then
-		if [[ "${distro}" == "Cygwin" || "${distro}" == "Haiku" ]]; then
+		if [[ "${distro}" == "Cygwin" || "${distro}" == "Haiku" || "${OSTYPE}" == "gnu" ]]; then
 			shell_type=$(echo "$SHELL" | awk -F'/' '{print $NF}')
 		else
 			if [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" ]]; then
@@ -3681,6 +3689,35 @@ asciiText () {
 "                            %s"
 "                            %s"
 "                            %s")
+
+			elif [[ "$(echo "${kernel}" | grep 'GNU' )" || "$(echo "${kernel}" | grep 'Hurd' )" || "${OSTYPE}" == "gnu" ]]; then
+				startline="0"
+				fulloutput=(
+"    _-\`\`\`\`\`-,           ,- '- .       %s"
+"   .'   .- - |          | - -.  \`.   %s"
+"  /.'  /                     \`.   \\  %s"
+" :/   :      _...   ..._      \`\`   : %s"
+" ::   :     /._ .\`:'_.._\\.    ||   : %s"
+" ::    \`._ ./  ,\`  :    \\ . _.''   . %s"
+" \`:.      /   |  -.  \\-. \\\\\_      /  %s"
+"   \\:._ _/  .'   .@)  \\@) \` \`\\ ,.'   %s"
+"      _/,--'       .- .\\,-.\`--\`.     %s"
+"        ,'/''     (( \\ \`  )          %s"
+"         /'/'  \\    \`-'  (           %s"
+"          '/''  \`._,-----'           %s"
+"           ''/'    .,---'            %s"
+"            ''/'      ;:             %s"
+"              ''/''  ''/             %s"
+"                ''/''/''             %s"
+"                  '/'/'              %s"
+"                   \`;                %s")
+# Source: https://www.gnu.org/graphics/alternative-ascii.en.html
+# Copyright (C) 2003, Vijay Kumar
+# Permission is granted to copy, distribute and/or modify this image under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+
 			else
 				if [[ "$no_color" != "1" ]]; then
 					c1=$(getColor 'light green') # Light Green


### PR DESCRIPTION
Appearently there's no `/proc/cpuinfo` or any kind of sysinfo command on GNU/Hurd to print the CPU type.
I've tested it on Debian/Hurd with unstable repositories enabled. The uptime command is broken, I don't know if that's a general GNU/Hurd issue or just specific to Debian/Hurd.

![debian_hurd-sf](https://cloud.githubusercontent.com/assets/5700937/7050330/fbc9788c-de20-11e4-8443-6c9bdccfa1a6.png)

In case of unkown distribution this logo will be shown:
```
djcj Downloads $ ./screenfetch-unix-hurd -D Unknown
    _-`````-,           ,- '- .       djcj@djcj-GF8100-M2-TE
   .'   .- - |          | - -.  `.    OS: unknown 
  /.'  /                     `.   \   Kernel: GNU-Mach/Hurd
 :/   :      _...   ..._      ``   :  Uptime: 4h 18m
 ::   :     /._ .`:'_.._\.    ||   :  Packages: Unknown
 ::    `._ ./  ,`  :    \ . _.''   .  Shell: bash 4.3.11
 `:.      /   |  -.  \-. \\_      /   Resolution: 1920x1080
   \:._ _/  .'   .@)  \@) ` `\ ,.'    DE: MATE 1.8.2
      _/,--'       .- .\,-.`--`.      WM: Metacity (Marco)
        ,'/''     (( \ `  )           GTK Theme: 'BlueMenta' [GTK2/3]
         /'/'  \    `-'  (            Icon Theme: Mint-X-Aqua
          '/''  `._,-----'            Font: Ubuntu 12
           ''/'    .,---'             CPU: Unkown x86
            ''/'      ;:              GPU: GeForce 8100 / nForce 720a
              ''/''  ''/              RAM: 261MB / 867MB
                ''/''/''             
                  '/'/'              
                   `;                
```
The logo was copied from https://www.gnu.org/graphics/alternative-ascii.en.html and is GPL-3 compatible.

And here's the output of the uname commands in case you're interrested:
![debian_hurd-uname](https://cloud.githubusercontent.com/assets/5700937/7050525/38389b80-de22-11e4-9946-94ce04f78f32.png)
