### PR TITLE
Count Chocolatey packages in Cygwin if present

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -877,7 +877,14 @@ detectpkgs () {
 			pkgs=$(if TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexistent pkg info pkg >/dev/null 2>&1; then 
 				pkg info | wc -l | awk '{print $1}'; else pkg_info | wc -l | awk '{sub(" ", "");print $1}'; fi)
 		;;
-		'Cygwin') cygfix=2; pkgs=$(($(cygcheck -cd | wc -l)-$cygfix)) ;;
+		'Cygwin')
+			cygfix=2
+			pkgs=$(($(cygcheck -cd | wc -l) - ${cygfix}))
+			if [ -d "/cygdrive/c/ProgramData/chocolatey/lib" ]; then
+				chocopkgs=$(( $(ls -1 /cygdrive/c/ProgramData/chocolatey/lib | wc -l) ))
+				pkgs=$((${pkgs} + ${chocopkgs}))
+			fi
+		;;
 	esac
 	verboseOut "Finding current package count...found as '$pkgs'"
 }


### PR DESCRIPTION
See https://chocolatey.org/
The path `C:\ProgramData\chocolatey` is automatically set during install and can't be changed without modifying the install script, so looking there for package entries should be a reliable method.