### PR TITLE
adding fix for gnome session fallback

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1338,6 +1338,12 @@ detectde () {
 					fi
 				fi
 
+				case "$DESKTOP_SESSION" in
+					gnome|gnome-fallback|gnome-fallback-compiz )
+						DE=Gnome
+						;;
+				esac
+
 				if [ x"$DE" = x"" ]; then
 					# fallback to checking $DESKTOP_SESSION
 					case "$DESKTOP_SESSION" in


### PR DESCRIPTION
According to discussion with @darealshinji in #265, I'm adding fix for gnome session fallback.
It was tested on Ubuntu Linux with Gnome (Compiz), Gnome (Metacity) and works correctly (displays Gnome as DE). For Unity it also behaves correctly (displays Unity as DE).