### PR TITLE
Minor fixes for OpenBSD

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1117,7 +1117,7 @@ detectmem () {
 		used_mem=$(($round_mem - $avail_mem))
 		usedmem=$(($used_mem / ($human * $human) ))
 	elif [ "$distro" == "OpenBSD" ]; then
-		totalmem=$(dmesg | grep 'real mem' | cut -d' ' -f5 | tr -d '()MB')
+		totalmem=$(grep 'real mem' /var/run/dmesg.boot | cut -d' ' -f6 | tr -d '()MB')
 		usedmem=$(top -1 1 | awk '/Real:/ {print $3}' | sed 's/M.*//')
 	elif [ "$distro" == "NetBSD" ]; then
 		phys_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1012,7 +1012,7 @@ detectgpu () {
 		gpu="${gpu_info##*device*= }"
 		gpu="${gpu//\'}"
 		# gpu=$(sed 's/.*device.*= //' <<< "${gpu_info}" | sed "s/'//g")
-	elif [[ "${distro}" != "Mac OS X" && "${distro}" != "Haiku" ]]; then
+	elif [[ "${distro}" != "Mac OS X" && "${distro}" != "Haiku" && "${distro}" != "OpenBSD" ]]; then
 		if [[ -n "$(PATH="/opt/bin:$PATH" type -p nvidia-smi)" ]]; then
 			gpu=$($(PATH="/opt/bin:$PATH" type -p nvidia-smi | cut -f1) -q | awk -F':' '/Product Name/ {gsub(/: /,":"); print $2}' | sed ':a;N;$!ba;s/\n/, /g')
 		elif [[ -n "$(PATH="/usr/sbin:$PATH" type -p glxinfo)" && -z "${gpu}" ]]; then


### PR DESCRIPTION
The sed expression `'1h;2,$H;${g;s/\n/, /g;p}'` results in the following output, so I've disabled GPU detection for OpenBSD until compatible code is written:

```
[[ ! ]] sed: 1: "1h;2,$H;${g;s/
/,/g;p}": extra characters at the end of p command
```

Using dmesg to fetch the total memory stops working when a computer has been on for a long time because the buffer is of a limited length, so I've replaced it by grepping on `/var/run/dmesg.boot`, and corrected the cut field number from 5 to 6.
