### PR TITLE
screenfetch-dev: change for CRUX

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -747,10 +747,6 @@ detectdistro () {
 		fi
 	fi
 
-	if [[ -n ${distro_more} ]]; then
-		distro_more="${distro} ${distro_more}"
-	fi
-
 	case $distro in
 		antergos) distro="Antergos" ;;
 		arch*linux*old) distro="Arch Linux - Old" ;;


### PR DESCRIPTION
Before I change, it looks like below.
![screenfetch-2015-09-16_22-33-13](https://cloud.githubusercontent.com/assets/7656607/9898944/1de1cf32-5c89-11e5-9acb-158c7243c282.png)

You see, in line "OS: crux CRUX 3.1" , lower case "crux" is totally needless. So need to change.
