### PR TITLE
display exact release version on Windows 10

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -4045,8 +4045,7 @@ infoDisplay () {
 				if [ -n "$distro_more" ]; then mydistro=$(echo -e "$labelcolor OS:$textcolor $distro_more $sysArch")
 				else mydistro=$(echo -e "$labelcolor OS:$textcolor $sysArch $distro $prodVers $buildVers"); fi
 			elif [[ "$distro" == "Cygwin" ]]; then
-				distro=$(wmic os get name | head -2 | tail -1)
-				distro=$(expr match "$distro" '\(Microsoft Windows [A-Za-z0-9.]\+\)')
+				distro="$(wmic os get caption | sed 's/\r//g; s/[ \t]*$//g; 2!d')"
 				if [[ "$(wmic os get version | grep -o '^10\.')" == "10." ]]; then
 					distro="$distro (v$(wmic os get version | grep '^10\.' | tr -d ' '))"
 				fi

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -4047,6 +4047,9 @@ infoDisplay () {
 			elif [[ "$distro" == "Cygwin" ]]; then
 				distro=$(wmic os get name | head -2 | tail -1)
 				distro=$(expr match "$distro" '\(Microsoft Windows [A-Za-z0-9.]\+\)')
+				if [[ "$(wmic os get version | grep -o '^10\.')" == "10." ]]; then
+					distro="$distro (v$(wmic os get version | grep '^10\.' | tr -d ' '))"
+				fi
 				sysArch=$(wmic os get OSArchitecture | head -2 | tail -1 | tr -d '\r ')
 				mydistro=$(echo -e "$labelcolor OS:$textcolor $distro $sysArch")
 			else

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -4049,7 +4049,7 @@ infoDisplay () {
 				if [[ "$(wmic os get version | grep -o '^10\.')" == "10." ]]; then
 					distro="$distro (v$(wmic os get version | grep '^10\.' | tr -d ' '))"
 				fi
-				sysArch=$(wmic os get OSArchitecture | head -2 | tail -1 | tr -d '\r ')
+				sysArch=$(wmic os get OSArchitecture | sed 's/\r//g; s/[ \t]*$//g; 2!d')
 				mydistro=$(echo -e "$labelcolor OS:$textcolor $distro $sysArch")
 			else
 				if [ -n "$distro_more" ]; then mydistro=$(echo -e "$labelcolor OS:$textcolor $distro_more")


### PR DESCRIPTION
Since we won't see a "Windows 11" release for a while.
Also the description should now include the OS edition.
Example: `OS: Microsoft Windows 10 Pro (v10.0.10586) 64-bit`