### PR TITLE
OpenBSD fixes

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1061,7 +1061,7 @@ detectgpu () {
 		gpu="${gpu_info##*device*= }"
 		gpu="${gpu//\'}"
 		# gpu=$(sed 's/.*device.*= //' <<< "${gpu_info}" | sed "s/'//g")
-	elif [[ "${distro}" != "Mac OS X" && "${distro}" != "Haiku" ]]; then
+	elif [[ "${distro}" != "Mac OS X" && "${distro}" != "Haiku" && "${distro}" != "OpenBSD" ]]; then
 		if [[ -n "$(PATH="/opt/bin:$PATH" type -p nvidia-smi)" ]]; then
 			gpu=$($(PATH="/opt/bin:$PATH" type -p nvidia-smi | cut -f1) -q | awk -F':' '/Product Name/ {gsub(/: /,":"); print $2}' | sed ':a;N;$!ba;s/\n/, /g')
 		elif [[ -n "$(PATH="/usr/sbin:$PATH" type -p glxinfo)" && -z "${gpu}" ]]; then
@@ -1073,6 +1073,8 @@ detectgpu () {
 			gpu_info=$($(PATH="/usr/bin:$PATH" type -p lspci | cut -f1) 2> /dev/null | grep VGA)
 			gpu=$(grep -oE '\[.*\]' <<< "${gpu_info}" | sed 's/\[//;s/\]//' | sed -n '1h;2,$H;${g;s/\n/, /g;p}')
 		fi
+	elif [[ "${distro}" == "OpenBSD" ]]; then
+		gpu=$(glxinfo | grep 'OpenGL renderer string' | sed 's/OpenGL renderer string: //')
 	elif [[ "${distro}" == "Mac OS X" ]]; then
 		gpu=$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {print $2}' | awk '{ printf "%s / ", $0 }' | sed -e 's/\/ $//g')
 	elif [[ "${distro}" == "Cygwin" ]]; then

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1168,8 +1168,8 @@ detectmem () {
 		used_mem=$(($round_mem - $avail_mem))
 		usedmem=$(($used_mem / ($human * $human) ))
 	elif [ "$distro" == "OpenBSD" ]; then
-		totalmem=$(dmesg | grep 'real mem' | cut -d' ' -f5 | tr -d '()MB')
-		usedmem=$(top -1 1 | awk '/Real:/ {print $3}' | sed 's/M.*//')
+		totalmem=$(($(sysctl -n hw.physmem) / 1024 / 1024))
+		usedmem=$(($(vmstat | sed -n 3p | cut -d' ' -f5) / 1024))
 	elif [ "$distro" == "NetBSD" ]; then
 		phys_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)
 		totalmem=$((${phys_mem} / $human))


### PR DESCRIPTION
I installed a really leet operating system (perhaps the leetest of them all), and would like to show off to my NEET friends. However, screenfetch upstream currently seems to be broken on OpenBSD. Here are a few hacks that got screenfetch working on OpenBSD.

A screenshot with the added fixes. My NEET friends were very pleased.
![2015-12-12-141930_1366x768_scrot](https://cloud.githubusercontent.com/assets/447479/11764233/d7fc7ca4-a0dc-11e5-99ab-22aebc781106.png)


