### PR TITLE
Use portable SED syntax.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1066,7 +1066,7 @@ detectgpu () {
 			gpu=$($(PATH="/opt/bin:$PATH" type -p nvidia-smi | cut -f1) -q | awk -F':' '/Product Name/ {gsub(/: /,":"); print $2}' | sed ':a;N;$!ba;s/\n/, /g')
 		elif [[ -n "$(PATH="/usr/sbin:$PATH" type -p glxinfo)" && -z "${gpu}" ]]; then
 			gpu_info=$($(PATH="/usr/sbin:$PATH" type -p glxinfo | cut -f1) 2>/dev/null)
-			gpu=$(grep "OpenGL renderer string" <<< "${gpu_info}" | cut -d ':' -f2  | sed -n '1h;2,$H;${g;s/\n/,/g;p}')
+			gpu=$(grep "OpenGL renderer string" <<< "${gpu_info}" | cut -d ':' -f2  | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g')
 			gpu="${gpu:1}"
 			gpu_info=$(grep "OpenGL vendor string" <<< "${gpu_info}")
 		elif [[ -n "$(PATH="/usr/sbin:$PATH" type -p lspci)" && -z "$gpu" ]]; then


### PR DESCRIPTION
I had some issues running screenfetch on OpenBSD because of some sed issues. You know BSD sed vs. GNU sed. The line I replaced should now be portable but I don't have a GNU/Linux at hand to test it with. So if you could, I'd appreciate it.