### PR TITLE
Improvements to OS X font detection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1888,7 +1888,20 @@ detectgtk () {
 		gtkIcons="Not Applicable"
 		if ps -U ${USER} | grep [F]inder >/dev/null 2>&1; then
 			if [ -f ~/Library/Preferences/com.googlecode.iterm2.plist ]; then
-				gtkFont=$(str1=$(defaults read com.googlecode.iTerm2|grep -m 1 "Normal Font");echo ${str1:29:${#str1}-29-2})
+				iterm2_theme_uuid=$(defaults read com.googlecode.iTerm2 "Default Bookmark Guid")
+
+				OLD_IFS=$IFS
+				IFS=$'\n'
+				iterm2_theme_info=($(defaults read com.googlecode.iTerm2 "New Bookmarks" | grep -e Guid -e "Normal Font"))
+				IFS=$OLD_IFS
+
+				for i in $(seq 0 $((${#iterm2_theme_info[*]}/2-1))); do
+					found_uuid=$(str1=${iterm2_theme_info[$i*2]};echo ${str1:16:${#str1}-16-2})
+					if [[ $found_uuid == $iterm2_theme_uuid ]]; then
+						gtkFont=$(str2=${iterm2_theme_info[$i*2+1]};echo ${str2:25:${#str2}-25-2})
+						break
+					fi
+				done
 			fi
 		fi
 	else

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1888,6 +1888,8 @@ detectgtk () {
 		gtkIcons="Not Applicable"
 		if ps -U ${USER} | grep [F]inder >/dev/null 2>&1; then
 			if [ -f ~/Library/Preferences/com.googlecode.iterm2.plist ]; then
+				# iTerm2
+
 				iterm2_theme_uuid=$(defaults read com.googlecode.iTerm2 "Default Bookmark Guid")
 
 				OLD_IFS=$IFS
@@ -1899,6 +1901,24 @@ detectgtk () {
 					found_uuid=$(str1=${iterm2_theme_info[$i*2]};echo ${str1:16:${#str1}-16-2})
 					if [[ $found_uuid == $iterm2_theme_uuid ]]; then
 						gtkFont=$(str2=${iterm2_theme_info[$i*2+1]};echo ${str2:25:${#str2}-25-2})
+						break
+					fi
+				done
+			else
+				# Terminal.app
+
+				termapp_theme_name=$(defaults read com.apple.Terminal "Default Window Settings")
+				
+				OLD_IFS=$IFS
+				IFS=$'\n'
+				termapp_theme_info=($(defaults read com.apple.Terminal "Window Settings" | grep -e "name = " -e "Font = "))
+				IFS=$OLD_IFS
+
+				for i in $(seq 0 $((${#termapp_theme_info[*]}/2-1))); do
+					found_name=$(str1=${termapp_theme_info[$i*2+1]};echo ${str1:15:${#str1}-15-1})
+					if [[ $found_name == $termapp_theme_name ]]; then
+						gtkFont=$(str2=${termapp_theme_info[$i*2]};echo ${str2:288:${#str2}-288})
+						gtkFont=$(echo ${gtkFont%%[dD]2*;} | xxd -r -p)
 						break
 					fi
 				done


### PR DESCRIPTION
I noticed that the font reported by screenfetch was wrong on my computer, so I decided to look into it.  Turns out the old version just grabbed the font from whatever iTerm2 profile was _listed_ first in the latter's preferences, rather than the default profile.  I changed it so that screenfetch looks up the GUID of the default profile first, then finds the font from that profile.  Since there's no good way to drill down multi-level OS X settings using `defaults`, the method's a bit hackish but seems to work.

I also added a fallback to Terminal.app's default profile font if iTerm2 is not installed.  That was similar but a bit harder since the font is stored as a binary sub-plist; I couldn't figure out how to extract the font size unfortunately.