### PR TITLE
passing "Linux Mint" with the -D argument also now prints the mint art

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -786,7 +786,7 @@ detectdistro () {
 		mandriva) distro="Mandriva" ;;
 		mandrake) distro="Mandrake" ;;
 		mer) distro="Mer" ;;
-		mint) distro="Mint" ;;
+		mint|linux*mint) distro="Mint" ;;
 		nix|nix*os) distro="NixOS" ;;
 		kali*linux) distro="Kali Linux" ;;
 		lmde) distro="LMDE" ;;


### PR DESCRIPTION
Running `screenfetch -D 'Linux Mint'` Doesn't print the ASCII art for Mint, this commit now prints the mint art for both `screenfetch -D 'Linux Mint'` and `screenfetch -D 'Mint'`