### PR TITLE
No longer gets iTerm's font while in Terminal.app

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2125,7 +2125,7 @@ detectgtk () {
 		gtk3Theme="Not Applicable"
 		gtkIcons="Not Applicable"
 		if ps -U ${USER} | grep [F]inder >/dev/null 2>&1; then
-			if [ -f ~/Library/Preferences/com.googlecode.iterm2.plist ]; then
+			if [[ ${TERM_PROGRAM} == "iTerm.app" ]] && [ -f ~/Library/Preferences/com.googlecode.iterm2.plist ]; then
 				# iTerm2
 
 				iterm2_theme_uuid=$(defaults read com.googlecode.iTerm2 "Default Bookmark Guid")


### PR DESCRIPTION
When looking for the font on OS X, it assumed that if you have iTerm installed, you're also using it, so calling screenfetch in Terminal.app would then grab iTerm's default font:
![screen shot 2016-10-02 at 02 34 01](https://cloud.githubusercontent.com/assets/13054393/19017822/3e6bb068-884a-11e6-99b6-970d19ae954c.png)

Fixed this by adding a check on the $TERM_PROGRAM environment variable:
![screen shot 2016-10-02 at 02 34 40](https://cloud.githubusercontent.com/assets/13054393/19017823/44b9b122-884a-11e6-84a5-89e0c0988e68.png)

