### PR TITLE
Rely on `uname' output for *BSD os decection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -582,9 +582,14 @@ detectdistro () {
 		# Existing File Check
 		if [ "$distro" == "Unknown" ]; then
 			if [ $(uname -o 2>/dev/null) ]; then
-				case "$(uname -o)" in
-					"Cygwin")
-						distro="Cygwin"
+				os="$(uname -o)"
+				case "$os" in
+					"Cygwin"|"FreeBSD"|"OpenBSD"|"NetBSD")
+						distro="$os"
+						fake_distro="${distro}"
+					;;
+					"DragonFly")
+						distro="DragonFlyBSD"
 						fake_distro="${distro}"
 					;;
 					"Msys")


### PR DESCRIPTION
`uname` may be used to reliably detect most *BSD OSes (namely FreeBSD,
NetBSD, OpenBSD, DragonFly), so use it. Otherwise it falls back to
`/var/run/dmesg.boot`, which is not always available (e.g. jails) and
is not as reliable anyway.

PS. Not sure what's `fake_distro` for, maybe it should just set `distro` for these systems.
