### PR TITLE
OpenBSD: fix usedmem for values < 100000 KiB

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1354,7 +1354,7 @@ detectmem () {
 		usedmem=$(($used_mem / ($human * $human) ))
 	elif [ "$distro" == "OpenBSD" ]; then
 		totalmem=$(($(sysctl -n hw.physmem) / $human / $human))
-		usedmem=$(($(vmstat | sed -n 3p | cut -d' ' -f5) / $human))
+		usedmem=$(($(vmstat | sed -n 3p | awk '{ print $4 }') / $human))
 	elif [ "$distro" == "NetBSD" ]; then
 		phys_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)
 		totalmem=$((${phys_mem} / $human))


### PR DESCRIPTION
cut(1) with `-d ' '` breaks when the number of spaces between fields changes, such that the vmstat(1) command only yields a value when it takes up six or more digits.

It might be a good idea to verify that none of the other invocations of cut(1) with `-d ' '` (or similar) operate on data that use the same character for padding and delimiting fields.