### PR TITLE
OpenBSD: glxinfo(1): suppress standard error

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1245,7 +1245,7 @@ detectgpu () {
 			# gpu=$(sed 's/.*device.*= //' <<< "${gpu_info}" | sed "s/'//g")
 		fi
 	elif [[ "${distro}" == "OpenBSD" ]]; then
-		gpu=$(glxinfo | grep 'OpenGL renderer string' | sed 's/OpenGL renderer string: //')
+		gpu=$(glxinfo 2> /dev/null | grep 'OpenGL renderer string' | sed 's/OpenGL renderer string: //')
 	elif [[ "${distro}" == "Mac OS X" ]]; then
 		gpu=$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {print $2}' | awk '{ printf "%s / ", $0 }' | sed -e 's/\/ $//g')
 	elif [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" ]]; then


### PR DESCRIPTION
This pull request suppresses the following error messages, which users might encounter when their session isn’t associated with an X display, or when glxinfo(1) hasn’t been installed:

```
Error: unable to open display
glxinfo: command not found
```