### PR TITLE
fix gnome-terminal error

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -28,9 +28,7 @@
 #                        curl (screenshot uploading)
 
 
-LANG=C
-LANGUAGE=C
-LC_ALL=C
+
 
 scriptVersion="3.7.0"
 

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -28,6 +28,9 @@
 #                        curl (screenshot uploading)
 
 
+#LANG=C
+#LANGUAGE=C
+#LC_ALL=C
 
 
 scriptVersion="3.7.0"


### PR DESCRIPTION
Fix when screenfetch is executed from gnome-terminal, gnome-terminal cannot be opened.