### PR TITLE
 Exceptions for the BunsenLabs desktop

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2294,6 +2294,7 @@ detectgtk () {
 			'XFCE'*) # Desktop Environment found as "XFCE"
 				if [ "$distro" == "BunsenLabs" ] ; then
 					gtk2Theme=$(awk -F'"' '/^gtk-theme/ {print $2}' $HOME/.gtkrc-2.0)
+					gtk3Theme=$(awk -F'=' '/^gtk-theme-name/ {print $2}' $HOME/.config/gtk-3.0/settings.ini)
 					gtkIcons=$(awk -F'"' '/^gtk-icon-theme/ {print $2}' $HOME/.gtkrc-2.0)
 					gtkFont=$(awk -F'"' '/^gtk-font-name/ {print $2}' $HOME/.gtkrc-2.0)
 				else

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2292,16 +2292,22 @@ detectgtk () {
 				#fi
 			;;
 			'XFCE'*) # Desktop Environment found as "XFCE"
-				if type -p xfconf-query >/dev/null 2>&1; then
-					gtk2Theme=$(xfconf-query -c xsettings -p /Net/ThemeName)
-				fi
+				if [ "$distro" == "BunsenLabs" ] ; then
+					gtk2Theme=$(awk -F'"' '/^gtk-theme/ {print $2}' $HOME/.gtkrc-2.0)
+					gtkIcons=$(awk -F'"' '/^gtk-icon-theme/ {print $2}' $HOME/.gtkrc-2.0)
+					gtkFont=$(awk -F'"' '/^gtk-font-name/ {print $2}' $HOME/.gtkrc-2.0)
+				else
+					if type -p xfconf-query >/dev/null 2>&1; then
+						gtk2Theme=$(xfconf-query -c xsettings -p /Net/ThemeName)
+					fi
 
-				if type -p xfconf-query >/dev/null 2>&1; then
-					gtkIcons=$(xfconf-query -c xsettings -p /Net/IconThemeName)
-				fi
+					if type -p xfconf-query >/dev/null 2>&1; then
+						gtkIcons=$(xfconf-query -c xsettings -p /Net/IconThemeName)
+					fi
 
-				if type -p xfconf-query >/dev/null 2>&1; then
-					gtkFont=$(xfconf-query -c xsettings -p /Gtk/FontName)
+					if type -p xfconf-query >/dev/null 2>&1; then
+						gtkFont=$(xfconf-query -c xsettings -p /Gtk/FontName)
+					fi
 				fi
 			;;
 			'LXDE'*)


### PR DESCRIPTION
BunsenLabs exports XDG_CURRENT_DESKTOP=XFCE but does not set any of the *xfconf* channels, this produces error messages and does not list the GTK theme & font name.

I have added an exception for BunsenLabs to fix this.