### PR TITLE
Fix gpu variable check esp it's empty

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1338,7 +1338,7 @@ DetectIntelGPU() {
 		*intel*) gpu=intel ;;
 	esac
 
-        if [ $gpu = intel ]; then
+        if [[ $gpu = intel ]]; then
 		#Detect CPU
 		local CPU=$(uname -p | awk '{print $3}')
 		CPU=${CPU#*'-'}; #Detect CPU number


### PR DESCRIPTION
Fix for the following problem:
```
/usr/bin/screenfetch: line 1341: [: =: unary operator expected
```