### PR TITLE
[#456] Fix readlink error on OSX

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1492,7 +1492,7 @@ detectshell () {
 	if [[ ! "${shell_type}" ]]; then
 		if [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" || "${distro}" == "Haiku" || "${distro}" == "Alpine Linux" || "${OSTYPE}" == "gnu" || "${distro}" == "TinyCore" || "${distro}" == "Raspbian" ]]; then
 			shell_type=$(echo "$SHELL" | awk -F'/' '{print $NF}')
-		elif readlink -f "$SHELL" | grep -q "busybox"; then
+		elif stat "$SHELL" | grep -q "busybox"; then
 			shell_type="BusyBox"
 		else
 			if [[ "${OSTYPE}" == "linux-gnu" || "${OSTYPE}" == "linux" || "${OSTYPE}" == "linux-musl" ]]; then


### PR DESCRIPTION
readlink does not have the same options on OSX as it does in Linux.
Both linux and OSX have stat. On Linux running BusyBox switching out
`readlink -f "$SHELL" | grep -q "busybox"` for `stat "$SHELL" | grep -q "busybox"`
still returns as expected and does not throw an error on OSX.