### PR TITLE
Fix typo: /dev/nulll -> /dev/null

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -633,7 +633,7 @@ detectdistro () {
 							distro="NixOS"
 							distro_more="$(nixos-version)"
 						fi
-						if (type -p guix && type -p herd) >/dev/nulll 2>&1; then
+						if (type -p guix && type -p herd) >/dev/null 2>&1; then
 							distro="GuixSD"
 						fi
 					;;


### PR DESCRIPTION
Just came across this when downloading the script onto a machine that didn't have the package available.