### PR TITLE
Manjaro logo formatting

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -4153,9 +4153,9 @@ asciiText () {
 				c1=$(getColor 'light green') # Green
 			fi
 			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; fi
-			startline="0"
+			startline="1"
 			logowidth="33"
-			fulloutput=(
+			fulloutput=(""
 "${c1} ██████████████████  ████████    %s"
 "${c1} ██████████████████  ████████    %s"
 "${c1} ██████████████████  ████████    %s"


### PR DESCRIPTION
Just a slight cosmetical improvement.
It doesn't look so good when the first horizontal line is glued to the last preceding terminal line without a space I think.

before:
![screenfetch_old](https://user-images.githubusercontent.com/11800714/27542025-460809ca-5a86-11e7-941f-dd824f292511.png)

after:
![screenfetch_new](https://user-images.githubusercontent.com/11800714/27542061-5f97f6b6-5a86-11e7-99cf-3ce1e82ed24c.png)
