### PR TITLE
fix(wm: theme: awesome): extend regex for matching theme name

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2023,7 +2023,7 @@ detectwmtheme () {
 	case $WM in
 		'2bwm') Win_theme="Not Applicable";;
 		'9wm') Win_theme="Not Applicable";;
-		'Awesome') if [ -f ${XDG_CONFIG_HOME:-${HOME}/.config}/awesome/rc.lua ]; then Win_theme="$(grep -e '^[^-].*\(theme\|beautiful\).*lua' ${XDG_CONFIG_HOME:-${HOME}/.config}/awesome/rc.lua | grep '[a-zA-Z0-9]\+/[a-zA-Z0-9]\+.lua' -o | cut -d'/' -f1 | head -n1)"; fi;;
+		'Awesome') if [ -f ${XDG_CONFIG_HOME:-${HOME}/.config}/awesome/rc.lua ]; then Win_theme="$(grep -e '^[^-].*\(theme\|beautiful\).*lua' ${XDG_CONFIG_HOME:-${HOME}/.config}/awesome/rc.lua | grep '[^/]\+/[^/]\+.lua' -o | cut -d'/' -f1 | head -n1)"; fi;;
 		'BlackBox') if [ -f $HOME/.blackboxrc ]; then Win_theme="$(awk -F"/" '/styleFile/ {print $NF}' $HOME/.blackboxrc)"; fi;;
 		'Beryl') Win_theme="Not Applicable";;
 		'bspwm') Win_theme="Not Applicable";;


### PR DESCRIPTION
for example, for theme names with `_` or `-` in the name