### PR TITLE
Arranged installation instructions, fixed Solus spacing, added Solus installation instructions

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -22,32 +22,19 @@ command! This script is very easy to add to and can easily be extended.
 
 1. Install `screenfetch` from the official repositories, e.g.: `installing screenfetch`
 
-### Netrunner Rolling
+### ChromeOS/ChromiumOS
 
-1. Install `screenfetch-netrunner` from the official repositories.
-
-### Mageia
-
-1. Install screenfetch from the official repositories with urpmi or rpmdrake.
-   e.g.: `urpmi screenfetch`
+0. Requires Developer Mode to be enabled. Instructions to enable it and enter the CLI are here - https://www.chromium.org/chromium-os/poking-around-your-chrome-os-device.
+1. Download the executable file and put it under the `/usr/local/bin/` directory: `wget -P /usr/local/bin/ https://raw.githubusercontent.com/KittyKatt/screenFetch/master/screenfetch-dev`
+2. Make the file executable by doing the following: `chmod +x /usr/local/bin/screenfetch-dev`
 
 ### Crux Linux
 
 1. Install screenfetch from either [6c37/crux-ports](https://github.com/6c37/crux-ports) or [6c37/crux-ports-git](https://github.com/6c37/crux-ports-git).
 
-### Mac
+### Fedora
 
-1. Run `brew install screenfetch` after installing [Homebrew](http://brew.sh)
-
-### Gentoo or Sabayon
-
-1. Emerge screenfetch from portage using `emerge screenfetch`
-2. Sabayon users can install screenfetch from entropy using `equo install screenfetch`
-
-### Ubuntu and Debian
-
-1. Install from the official repositories: `apt install screenfetch`
-2. There is also a PPA for Ubuntu located at https://launchpad.net/%7Edjcj/+archive/ubuntu/screenfetch
+1. Install it with dnf running: `dnf install screenfetch`
 
 ### FreeBSD
 
@@ -55,40 +42,52 @@ command! This script is very easy to add to and can easily be extended.
 2. Install screenfetch as a binary package: `pkg install screenFetch`
 3. Make sure fdescfs(5) and procfs(5) are mounted, they're required by bash(1).
 
-### Fedora
-
-1. Install it with dnf running: `dnf install screenfetch`
-
 ### Fux
 
 1. Installation: `dnf install screenfetch`
+
+### Gentoo or Sabayon
+
+1. Emerge screenfetch from portage using `emerge screenfetch`
+2. Sabayon users can install screenfetch from entropy using `equo install screenfetch`
 
 ### KaOS
 
 1. Install screenfetch from the official repositories with octopi or pacman.
    e.g.: `pacman -S screenfetch`
 
-### openSUSE
+### Mac
 
-1. If using 13.2 or earlier, add "utilities" repo: `zypper ar -r http://download.opensuse.org/repositories/utilities/openSUSE_$(lsb_release -rs)/utilities.repo`
-2. Install it with zypper running: `zypper install screenfetch`
+1. Run `brew install screenfetch` after installing [Homebrew](http://brew.sh)
+
+### Mageia
+
+1. Install screenfetch from the official repositories with urpmi or rpmdrake.
+   e.g.: `urpmi screenfetch`
 
 ### MSYS2
 
 1. Install screenfetch from the official repositories: `pacman -S screenfetch`
 
-### ChromeOS/ChromiumOS
+### Netrunner Rolling
 
-0. Requires Developer Mode to be enabled. Instructions to enable it and enter the CLI are here - https://www.chromium.org/chromium-os/poking-around-your-chrome-os-device.
-1. Download the executable file and put it under the `/usr/local/bin/` directory: `wget -P /usr/local/bin/ https://raw.githubusercontent.com/KittyKatt/screenFetch/master/screenfetch-dev`
-2. Make the file executable by doing the following: `chmod +x /usr/local/bin/screenfetch-dev`
+1. Install `screenfetch-netrunner` from the official repositories.
+
+### openSUSE
+
+1. If using 13.2 or earlier, add "utilities" repo: `zypper ar -r http://download.opensuse.org/repositories/utilities/openSUSE_$(lsb_release -rs)/utilities.repo`
+2. Install it with zypper running: `zypper install screenfetch`
+
+### Ubuntu and Debian
+
+1. Install from the official repositories: `apt install screenfetch`
+2. There is also a PPA for Ubuntu located at https://launchpad.net/%7Edjcj/+archive/ubuntu/screenfetch
 
 ### Others
 
 1. Download the latest source at https://github.com/KittyKatt/screenFetch: `wget -P /path/to/screenfetch/ https://raw.githubusercontent.com/KittyKatt/screenFetch/master/screenfetch-dev`
 2. In a terminal, make the file executable by doing the following: `chmod +x /path/to/screenfetch/screenfetch-dev`
 3. Then, either keep it there, or move it to somewhere in your $PATH to make it available without having to use the full path to the script.
-
 
 ## Running screenfetch
 
@@ -142,5 +141,3 @@ If you would like to suggest something new, inform me of an issue in the
 script, become part of the project, or talk to me about anything else,
 you can either email me at `zeldarealm@gmail.com` or you can connect
 to Rizon and reach me at `irc://irc.rizon.net/screenFetch`
-
-

--- a/README.mkdn
+++ b/README.mkdn
@@ -78,6 +78,10 @@ command! This script is very easy to add to and can easily be extended.
 1. If using 13.2 or earlier, add "utilities" repo: `zypper ar -r http://download.opensuse.org/repositories/utilities/openSUSE_$(lsb_release -rs)/utilities.repo`
 2. Install it with zypper running: `zypper install screenfetch`
 
+### Solus
+
+1. Install screenfetch from the official repositories by running `eopkg install screenfetch`
+
 ### Ubuntu and Debian
 
 1. Install from the official repositories: `apt install screenfetch`

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -3708,7 +3708,7 @@ asciiText () {
 			startline="0"
 			logowidth="36"
 			fulloutput=(
-"${c3}             ......                 %s"
+"${c3}               ......               %s"
 "${c3}         .'${c1}D${c3}lddddddddddd'.          %s"
 "${c3}      .'ddd${c1}XM${c3}xdddddddddddddd.       %s"
 "${c3}    .dddddx${c1}MMM0${c3};dddddddddddddd.     %s"

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -3573,7 +3573,7 @@ asciiText () {
 "${c1}         ROSA               SARO         %s"
 "${c1}            ROSAROSAROSAROSAR            %s")
 		;;
-    
+
 		"Red Hat Enterprise Linux")
 			if [[ "$no_color" != "1" ]]; then
 				c1=$(getColor 'white') # White
@@ -3708,7 +3708,7 @@ asciiText () {
 			startline="0"
 			logowidth="36"
 			fulloutput=(
-"${c3}             ......               %s"
+"${c3}             ......                 %s"
 "${c3}         .'${c1}D${c3}lddddddddddd'.          %s"
 "${c3}      .'ddd${c1}XM${c3}xdddddddddddddd.       %s"
 "${c3}    .dddddx${c1}MMM0${c3};dddddddddddddd.     %s"


### PR DESCRIPTION
I have arranged the installation instructions so the operating systems are now in alphabetical order, I have also added instructions for Solus as this is an independent Linux distribution using `eopkg` for package management.

The Solus logo had the spacing a bit off for the username@hostname information line and also the top of the circle, which I have fixed.

This is my first ever pull request, please tell me if I can improve!