### PR TITLE
Change package list request for Solus from pisi to eopkg

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1079,7 +1079,8 @@ detectpkgs () {
 		'GuixSD') pkgs=$(ls -d -1 /guix/store/*/ | wc -l) ;;
 		'Fedora'|'Fux'|'Korora'|'BLAG'|'Chapeau'|'openSUSE'|'SUSE Linux Enterprise'|'Red Hat Enterprise Linux'|'ROSA'|'Oracle Linux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'|'Red Star OS'|'blackPanther OS') pkgs=$(rpm -qa | wc -l) ;;
 		'Void Linux') pkgs=$(xbps-query -l | wc -l) ;;
-		'Evolve OS'|'Solus') pkgs=$(pisi list-installed | wc -l) ;;
+		'Evolve OS') pkgs=$(pisi list-installed | wc -l) ;;
+		'Solus') pkgs=$(eopkg list-installed | wc -l) ;;
 		'CRUX') pkgs=$(pkginfo -i | wc -l) ;;
 		'Lunar Linux') pkgs=$(lvu installed | wc -l) ;;
 		'TinyCore') pkgs=$(tce-status -i | wc -l) ;;


### PR DESCRIPTION
Solus still uses eopkg for package management. Sol has not been implemented yet and pisi does not work, implemented change as per the suggestion in from @tigos2 in #415 