### PR TITLE
detect POWER cpu (e.g. POWER8E)

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1204,6 +1204,8 @@ detectcpu () {
 				model="IBM PowerPC G3 "
 			elif [[ $cpu =~ ^74.+ ]]; then
 				model="Motorola PowerPC G4 "
+			elif [[ $cpu =~ ^POWER.* ]]; then
+				model="IBM POWER "
 			elif [[ "$(cat /proc/cpuinfo)" =~ "BCM2708" ]]; then
 				model="Broadcom BCM2835 ARM1176JZF-S"
 			else


### PR DESCRIPTION
Add IBMPOWER cpu detection, it was tested on Debian POWER8E porterbox (ppc64el).
see https://en.wikipedia.org/wiki/IBM_POWER_microprocessors for POWER series.
