### PR TITLE
screenfetch-dev: fixed OpenBSD usedmem.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1472,7 +1472,7 @@ detectmem () {
 		usedmem=$(($used_mem / 1024^2 ))
 	elif [ "$distro" == "OpenBSD" ]; then
 		totalmem=$(($(sysctl -n hw.physmem) / 1024 / 1024))
-		usedmem=$(($(vmstat | awk '!/[a-z]/{print $4}') / 1024))
+		usedmem=$(vmstat | awk '!/[a-z]/{gsub("M",""); print $3}')
 	elif [ "$distro" == "NetBSD" ]; then
 		phys_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)
 		totalmem=$((${phys_mem} / 1024))


### PR DESCRIPTION
Reverted the OpenBSD usedmem line to my working version.

The previous version tried to display the size of the free list, which is the amount of memory free rather than used; it also added an "M" at the end of the total which caused an error during the attempted arithmetical operation.

See http://daemonforums.org/showpost.php?p=62821&postcount=86