### PR TITLE
bugfix：in case there is ``` No such file or directory``` error.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1320,7 +1320,7 @@ detectcpu () {
 	if [ -d '/sys/class/hwmon/' ]; then
 		for dir in `echo $(ls /sys/class/hwmon/)`
 		do
-			if cat /sys/class/hwmon/$dir/name | grep coretemp > /dev/null
+			if cat /sys/class/hwmon/$dir/device/name | grep coretemp > /dev/null
 			then
 				thermal="/sys/class/hwmon/$dir/temp1_input"
 				break


### PR DESCRIPTION
Ⅰ. Describe what this PR did

in case there is ```cat: /sys/class/hwmon/hwmon0/name: No such file or directory``` error.

Ⅱ. Does this pull request fix one issue?
null

Ⅲ. Describe how you did it
```
[root@k8snode1 ~]# screenfetch
cat: /sys/class/hwmon/hwmon0/name: No such file or directory
cat: /sys/class/hwmon/hwmon1/name: No such file or directory
(.....)           
```
Ⅳ. Describe how to verify it

Ⅴ. Special notes for reviews

Ⅵ. Environment:
root@k8snode1
OS: CentOS 
Kernel: x86_64 Linux 3.10.0-327.el7.x86_64
Uptime: 19h 8m
Packages: 505
Shell: bash 4.2.46
CPU: Intel Core i7-7700HQ @ 4x 2.808GHz
GPU: svgadrmfb
RAM: 920MiB / 1824MiB
