### PR TITLE
Ignoring white spaces before the GTK3 theme name.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2670,7 +2670,7 @@ detectgtk () {
 				# EXPERIMENTAL gtk3 Theme detection
 				if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
 					if grep -q gtk-theme-name $HOME/.config/gtk-3.0/settings.ini; then
-						gtk3Theme=$(awk -F'=' '/^gtk-theme-name/ {print $2}' $HOME/.config/gtk-3.0/settings.ini)
+						gtk3Theme=$(awk -F'=\t*' '/^gtk-theme-name/ {print $2}' $HOME/.config/gtk-3.0/settings.ini)
 					fi
 				fi
 


### PR DESCRIPTION
Screenfetch copies every character after "=" from the settings.ini theme name string, including the white spaces. This behaviour could lead to a line breakage or/and inconsistent indentation at the script's output.

I think that all white spaces before the theme name must be ignored.