### PR TITLE
fix memory statistics on FreeBSD

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1604,7 +1604,7 @@ detectmem () {
 			size_chip=`echo "$size_chip * 2" | bc`
 		done
 		round_mem=`echo "( $size_mem / $size_chip + 1 ) * $size_chip " | bc`
-		totalmem=$(($round_mem / 1024^2 ))
+		totalmem=$(($round_mem / 1024 / 1024 ))
 		pagesize=$(sysctl -n hw.pagesize)
 		inactive_count=$(sysctl -n vm.stats.vm.v_inactive_count)
 		inactive_mem=$(($inactive_count * $pagesize))
@@ -1614,7 +1614,7 @@ detectmem () {
 		free_mem=$(($free_count * $pagesize))
 		avail_mem=$(($inactive_mem + $cache_mem + $free_mem))
 		used_mem=$(($round_mem - $avail_mem))
-		usedmem=$(($used_mem / 1024^2 ))
+		usedmem=$(($used_mem / 1024 / 1024 ))
 	elif [ "$distro" == "OpenBSD" ]; then
 		totalmem=$(($(sysctl -n hw.physmem) / 1024 / 1024))
 		usedmem=$(vmstat | awk '!/[a-z]/{gsub("M",""); print $3}')


### PR DESCRIPTION
The syntax '/ 1024^2' does not work in bash. The other instances of it are piped to bc, where it does work.

Switch to '/ 1024 / 1024' to scale the value to megabytes.

```
bash> echo "ram=$(sysctl -n hw.physmem)"
ram=34194522112
bash> echo "ram_mb=$(( $(sysctl -n hw.physmem) / 1024))"
ram_mb=33393088
bash> echo "ram_mb=$(( $(sysctl -n hw.physmem) / 1024^2))"
ram_mb=33393090
bash> echo "ram_mb=$(( $(sysctl -n hw.physmem) / 1024 / 1024))"
ram_mb=32610
```

This makes the output correct.

On my machine with 32GB of ram:
Before:
```
RAM: 30618762MiB / 33393090MiB
```

After:
```
RAM: 30057MiB / 32768MiB
```