### PR TITLE
Develop/eurolinux

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -894,7 +894,16 @@ detectdistro () {
 					if [[ "${distro}" == "Oracle Linux" && -f /etc/oracle-release ]]; then
 						distro_more="$(sed 's/Oracle Linux //' /etc/oracle-release)"
 					fi
-					[[ "${distro}" == "rhel" ]] && distro="Red Hat Enterprise Linux"
+					# Upstream problem, SL and so EL is using rhel ID in os-release
+					if [[ "${distro}" == "rhel" ]] || [[ "${distro}" == "Rhel" ]]; then
+						distro="Red Hat Enterprise Linux"
+						if grep -q 'Scientific' /etc/os-release; then
+							distro="Scientific Linux"
+						elif grep -q 'EuroLinux' /etc/os-release; then
+							distro="EuroLinux"
+						fi
+					fi	
+
 					[[ "${distro}" == "Neon" ]] && distro="KDE neon"
 					[[ "${distro}" == "SLED" || "${distro}" == "sled" || "${distro}" == "SLES" || "${distro}" == "sles" ]] && distro="SUSE Linux Enterprise"
 					if [[ "${distro}" == "SUSE Linux Enterprise" && -f /etc/os-release ]]; then
@@ -965,6 +974,7 @@ detectdistro () {
 					distro_more=$(grep -o '[0-9.]' /etc/redstar-release | tr -d '\n')
 				elif [[ "${distro}" == "redhat" ]]; then
 					grep -q -i 'CentOS' /etc/redhat-release && distro="CentOS"
+					grep -q -i 'Scientific' /etc/redhat-release && distro="Scientific Linux"
 					grep -q -i 'EuroLinux' /etc/redhat-release && distro="EuroLinux"
 					grep -q -i 'PCLinuxOS' /etc/redhat-release && distro="PCLinuxOS"
 					if [ "x$(od -t x1 /etc/redhat-release | sed -e 's/^\w*\ *//' | tr '\n' ' ' | grep 'eb b6 89 ec 9d 80 eb b3 84 ')" != "x" ]; then
@@ -1181,6 +1191,7 @@ detectdistro () {
 		red*star|red*star*os) distro="Red Star OS" ;;
 		sabayon) distro="Sabayon" ;;
 		sailfish|sailfish*os) distro="SailfishOS" ;;
+		scientific*) distro="Scientific Linux" ;;
 		siduction) distro="Siduction" ;;
 		slackware) distro="Slackware" ;;
 		smgl|source*mage|source*mage*gnu*linux) distro="Source Mage GNU/Linux" ;;
@@ -1314,7 +1325,7 @@ detectpkgs () {
 		'GuixSD')
 			pkgs=$(ls -d -1 /guix/store/*/ | wc -l) ;;
 		'ALDOS'|'Fedora'|'Fux'|'Korora'|'BLAG'|'Chapeau'|'openSUSE'|'SUSE Linux Enterprise'|'Red Hat Enterprise Linux'| \
-		'ROSA'|'Oracle Linux'|'EuroLinux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'| \
+		'ROSA'|'Oracle Linux'|'Scientific Linux'|'EuroLinux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'| \
 		'Red Star OS'|'blackPanther OS'|'Amazon Linux')
 			pkgs=$(rpm -qa | wc -l) ;;
 		'Void Linux')

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -355,7 +355,7 @@ detectColors () {
 
 supported_distros="ALDOS, Alpine Linux, Amazon Linux, Antergos, Arch Linux (Old and Current Logos), Artix Linux, \
 blackPanther OS, BLAG, BunsenLabs, CentOS, Chakra, Chapeau, Chrome OS, Chromium OS, CrunchBang, CRUX, \
-Debian, Deepin, DesaOS,Devuan, Dragora, EuroLinux, elementary OS, EuroLinux, Evolve OS, Exherbo, Fedora, Frugalware, Fuduntu, Funtoo, \
+Debian, Deepin, DesaOS,Devuan, Dragora, elementary OS, EuroLinux, Evolve OS, Exherbo, Fedora, Frugalware, Fuduntu, Funtoo, \
 Fux, Gentoo, gNewSense, GuixSD, Hyperbola GNU/Linux-libre, januslinux, Jiyuu Linux, Kali Linux, KaOS, KDE neon, Kogaion, Korora, \
 LinuxDeepin, Linux Mint, LMDE, Logos, Mageia, Mandriva/Mandrake, Manjaro, Mer, Netrunner, NixOS, OBRevenge, openSUSE, \
 OS Elbrus, Oracle Linux, Parabola GNU/Linux-libre, Pardus, Parrot Security, PCLinuxOS, PeppermintOS, Proxmox VE, PureOS, Qubes OS, \

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -355,7 +355,7 @@ detectColors () {
 
 supported_distros="ALDOS, Alpine Linux, Amazon Linux, Antergos, Arch Linux (Old and Current Logos), Artix Linux, \
 blackPanther OS, BLAG, BunsenLabs, CentOS, Chakra, Chapeau, Chrome OS, Chromium OS, CrunchBang, CRUX, \
-Debian, Deepin, DesaOS,Devuan, Dragora, elementary OS, Evolve OS, Exherbo, Fedora, Frugalware, Fuduntu, Funtoo, \
+Debian, Deepin, DesaOS,Devuan, Dragora, EuroLinux, elementary OS, EuroLinux, Evolve OS, Exherbo, Fedora, Frugalware, Fuduntu, Funtoo, \
 Fux, Gentoo, gNewSense, GuixSD, Hyperbola GNU/Linux-libre, januslinux, Jiyuu Linux, Kali Linux, KaOS, KDE neon, Kogaion, Korora, \
 LinuxDeepin, Linux Mint, LMDE, Logos, Mageia, Mandriva/Mandrake, Manjaro, Mer, Netrunner, NixOS, OBRevenge, openSUSE, \
 OS Elbrus, Oracle Linux, Parabola GNU/Linux-libre, Pardus, Parrot Security, PCLinuxOS, PeppermintOS, Proxmox VE, PureOS, Qubes OS, \
@@ -965,6 +965,7 @@ detectdistro () {
 					distro_more=$(grep -o '[0-9.]' /etc/redstar-release | tr -d '\n')
 				elif [[ "${distro}" == "redhat" ]]; then
 					grep -q -i 'CentOS' /etc/redhat-release && distro="CentOS"
+					grep -q -i 'EuroLinux' /etc/redhat-release && distro="EuroLinux"
 					grep -q -i 'PCLinuxOS' /etc/redhat-release && distro="PCLinuxOS"
 					if [ "x$(od -t x1 /etc/redhat-release | sed -e 's/^\w*\ *//' | tr '\n' ' ' | grep 'eb b6 89 ec 9d 80 eb b3 84 ')" != "x" ]; then
 						distro="Red Star OS"
@@ -1124,6 +1125,7 @@ detectdistro () {
 		dragonflybsd) distro="DragonFlyBSD" ;;
 		dragora) distro="Dragora" ;;
 		elementary|'elementary os') distro="elementary OS";;
+		eurolinux) distro="EuroLinux" ;;
 		evolveos) distro="Evolve OS" ;;
 		exherbo|exherbo*linux) distro="Exherbo" ;;
 		fedora) distro="Fedora" ;;
@@ -1312,7 +1314,7 @@ detectpkgs () {
 		'GuixSD')
 			pkgs=$(ls -d -1 /guix/store/*/ | wc -l) ;;
 		'ALDOS'|'Fedora'|'Fux'|'Korora'|'BLAG'|'Chapeau'|'openSUSE'|'SUSE Linux Enterprise'|'Red Hat Enterprise Linux'| \
-		'ROSA'|'Oracle Linux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'| \
+		'ROSA'|'Oracle Linux'|'EuroLinux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'| \
 		'Red Star OS'|'blackPanther OS'|'Amazon Linux')
 			pkgs=$(rpm -qa | wc -l) ;;
 		'Void Linux')
@@ -5412,6 +5414,43 @@ asciiText () {
 "${c2}                                     ''        %s"
 "${c2}                                               %s")
 		;;
+
+		"EuroLinux")
+			if [[ "$no_color" != "1" ]]; then
+				c1=$(getColor 'light blue')
+			fi
+			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}";fi;
+			startline="0"
+			logowidth="39"
+			fulloutput=(
+
+"${c1}                                       %s"
+"${c1}           DZZZZZZZZZZZZZ              %s" 
+"${c1}         ZZZZZZZZZZZZZZZZZZZ           %s"
+"${c1}          ZZZZZZZZZZZZZZZZZZZZ         %s"
+"${c1}           OZZZZZZZZZZZZZZZZZZZZ       %s"
+"${c1}   Z         ZZZ    8ZZZZZZZZZZZZ      %s" 
+"${c1}  ZZZ                   ZZZZZZZZZZ     %s"
+"${c1} ZZZZZN                   ZZZZZZZZZ    %s"
+"${c1} ZZZZZZZ                    ZZZZZZZZ   %s"
+"${c1}ZZZZZZZZ                    OZZZZZZZ   %s"
+"${c1}ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ  %s"
+"${c1}ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ  %s"
+"${c1}ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ  %s"
+"${c1}ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ   %s"
+"${c1}ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ    %s"
+"${c1}ZZZZZZZZ                               %s"
+"${c1} ZZZZZZZZ                              %s"
+"${c1} OZZZZZZZZO                            %s"
+"${c1}  ZZZZZZZZZZZ                          %s"
+"${c1}   OZZZZZZZZZZZZZZZN                   %s"
+"${c1}     ZZZZZZZZZZZZZZZZ                  %s"
+"${c1}      DZZZZZZZZZZZZZZZ                 %s"
+"${c1}         ZZZZZZZZZZZZZ                 %s"
+"${c1}            NZZZZZZZZ                  %s"
+"${c1}                                       %s")
+		;;
+
 
 		"OBRevenge")
 			if [[ "$no_color" != "1" ]]; then


### PR DESCRIPTION
This PR changes:

1) Adds support for EuroLinux distro.
2) Fix Scientific Linux not checking RPMS.
3) Fix Scientific Linux detection. 

I noticed that Oracle Detection on Oracle Linux 7.5 is not as expected (showing generic Linux). 

The main problem with RHEL-like distros is fact that distro checking is invoked in many places.
1) lsb_release, that might produced different output, but most important is ID and unfortunately both EuroLinux and SL presents themselves as rhel.
2) /etc/os-release
3) /etc/redhat-release
4) /etc/oracle-release

I would like to rebase script, but without some tests I may broke everything :).

PS. I currently investigating some options for testing. I will come back if I found something