### PR TITLE
Fix some edge cases for counting snap packages

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1391,10 +1391,13 @@ detectpkgs () {
 			fi
 		;;
 	esac
-	if [[ "${OSTYPE}" =~ "linux" ]] && snap list >/dev/null 2>&1; then
+	if [[ "${OSTYPE}" =~ "linux" && -z "${wsl}" ]] && snap list >/dev/null 2>&1; then
 		offset=1
-		snappkgs=$(snap list | wc -l)
-		pkgs=$((pkgs + (snappkgs - offset)))
+		snappkgs=$(($(snap list 2>/dev/null | wc -l) - offset))
+		if [ $snappkgs -lt 0 ]; then
+			snappkgs=0
+		fi
+		pkgs=$((pkgs + snappkgs))
 	fi
 	verboseOut "Finding current package count...found as '$pkgs'"
 }


### PR DESCRIPTION
I fixed some issues I ran into around counting snap packages:

1. If `snapd` is installed, but there are no snap packages installed, then `snap list` will still run successfully, but only outputs the following to stderr:
```
$ snap list
No snaps are installed yet. Try 'snap install hello-world'.
```
This error line is printed during `screenfetch`'s output. Fixed by suppressing stderr in the second call to `snap list`.

2. In the above scenario, `snap list` doesn't output anything to stdout, so we end up with -1 snap packages after accounting for the offset. So `screenfetch`'s count of packages is off by one. This is fixed by capping the package number at 0.

3. In the Windows Subsystem for Linux, snap is installed by default. However,[ WSL doesn't support systemd](https://github.com/Microsoft/WSL/issues/994), so when `snap list` tries to communicate with its service, it times out after around 5 seconds. Since we call it twice, this delays `screenfetch` by 10 seconds - quite painful if you put it in your `.bashrc`. The solution is just to exclude WSL from the snap count for now.