### PR TITLE
Set GPU to Not Found if Intel check fails

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1606,7 +1606,7 @@ DetectIntelGPU() {
 			gpu="intel"
 			;;
 		*)
-			gpu="Unknown"
+			gpu="Not Found"
 			;;
 	esac
 
@@ -1642,7 +1642,7 @@ DetectIntelGPU() {
 				#7th Kabylake
 				#8th Cannonlake
 			*)
-				gpu='Unknown'
+				gpu='Not Found'
 				;; #Unknown GPU model
 		esac
 	fi

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1642,7 +1642,7 @@ DetectIntelGPU() {
 				#7th Kabylake
 				#8th Cannonlake
 			*)
-				gpu='Not Found'
+				gpu='Unknown'
 				;; #Unknown GPU model
 		esac
 	fi


### PR DESCRIPTION
The intel GPU check sets `$gpu` to "Unknown" if the chip couldn't be identified. However, the script expects "Not Found" for these values.

This change sets the GPU back to "Not Found" if the Intel check fails, properly hiding the GPU printout if we couldn't identify it.