### PR TITLE
Fixed bug displaying font type on macos

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2548,6 +2548,7 @@ detectgtk () {
 					if [[ $found_name == $termapp_theme_name ]]; then
 						gtkFont=$(str2=${termapp_theme_info[$i*2]};echo "${str2:288:${#str2}-288}")
 						gtkFont=$(echo "${gtkFont%%[dD]2*;}" | xxd -r -p)
+						gtkFont=$(echo "${gtkFont:21:288}")
 						break
 					fi
 				done


### PR DESCRIPTION
Heres my PR from this issue i submitted earlier here: https://github.com/KittyKatt/screenFetch/issues/594

A simple one-line fix to remove the erroneous characters before the actual font name. I tested it on a couple different stock mono-spaced fonts and it works for me. The 288 was an arbitrary number i chose because it was sitting right above it in the code, and because i don't know how to make it always select the last char of the string. There were/are no excess characters behind the font name, only before, but font names can be fairly long, so I gave it plenty of space. 

The real problem was that the script was picking up 21 random characters(including a newline) from the `defaults read com.apple.Terminal "Window Settings"` command and the parsing lines. So I just cut them out of the string. 