### PR TITLE
Fixed issue where make.conf can be a include directory

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -647,7 +647,14 @@ detectdistro () {
 					else
 						distro="Gentoo"
 					fi
-					. /etc/portage/make.conf #detecting release stable/testing/experimental
+
+					#detecting release stable/testing/experimental
+					if [[ -f /etc/portage/make.conf ]]; then
+						source /etc/portage/make.conf
+					elif [[ -d /etc/portage/make.conf ]]; then
+						source /etc/portage/make.conf/*
+					fi
+
 					case $ACCEPT_KEYWORDS in
 						[a-z]*) distro_release=stable       ;;
 						~*)     distro_release=testing      ;;


### PR DESCRIPTION
The /etc/portage/make.conf can be a include directory, and when that is a directory it causes this error:
`./screenfetch-dev: line 650: .: /etc/portage/make.conf: is a directory`
This if statement check to see if /etc/portage/make.conf is a directory or regular file and then sources in the files according.