### PR TITLE
Fix gpu info being displayed across multiple lines error.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1605,7 +1605,7 @@ detectgpu () {
 # Run it only on Intel Processors if GPU is unknown
 DetectIntelGPU() {
 	if [ -r /proc/fb ]; then
-		gpu=$(awk '{print $2}' /proc/fb)
+		gpu=$(awk 'BEGIN {ORS = " &"} {$1="";print}' /proc/fb | sed  -r s/'^\s+|\s*&$'//g)
 	fi
 
 	case $gpu in


### PR DESCRIPTION
In case the `/proc/fb` file is
```
0 svgadrmfb
1 VESA VGA
```
screenfetch might reserve the line break with dropping out contents after the second space, so  $gpu is set to $'svgadrmfb\nVESA', which might be displayed as

```
   `/ossssso+/:-        -:/+osssso+-   GPU: svgadrmfb
VESA
  `+sso+:-`                 `.-/+oso: 
```