### PR TITLE
Adding support for LMDE 3

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -725,6 +725,9 @@ detectdistro () {
 						distro="LMDE"
 						distro_codename="n/a"
 						distro_release="n/a"
+					#adding support for LMDE 3	
+					elif [[ "$(lsb_release -sd)" =~ "LMDE" ]]; then
+						distro="LMDE"	
 					fi
 					;;
 				"openSUSE"|"openSUSE project"|"SUSE LINUX")


### PR DESCRIPTION
LMDE 3 uses code names, so its not recognized correctly. instead we use the release description.