### PR TITLE
update Red Hat Enterprise Linux with new 2019 logo

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -4063,31 +4063,30 @@ asciiText () {
 
 		"Red Hat Enterprise Linux")
 			if [[ "$no_color" != "1" ]]; then
-				c1=$(getColor 'white') # White
-				c2=$(getColor 'light red') # Light Red
+				c1=$(getColor 'light red') # Light Red
 			fi
-			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; c2="${my_lcolor}"; fi
+			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; fi
 			startline="0"
 			logowidth="42"
 			fulloutput=(
-"${c2}                                          %s"
-"${c2}              \`.-..........\`              %s"
-"${c2}             \`////////::.\`-/.             %s"
-"${c2}             -: ....-////////.            %s"
-"${c2}             //:-::///////////\`           %s"
-"${c2}      \`--::: \`-://////////////:           %s"
-"${c2}      //////-    \`\`.-:///////// .\`        %s"
-"${c2}      \`://////:-.\`    :///////::///:\`     %s"
-"${c2}        .-/////////:---/////////////:     %s"
-"${c2}           .-://////////////////////.     %s"
-"${c1}          yMN+\`.-${c2}::///////////////-\`      %s"
-"${c1}       .-\`:NMMNMs\`  \`..-------..\`         %s"
-"${c1}        MN+/mMMMMMhoooyysshsss            %s"
-"${c1} MMM    MMMMMMMMMMMMMMyyddMMM+            %s"
-"${c1}  MMMM   MMMMMMMMMMMMMNdyNMMh\`     hyhMMM %s"
-"${c1}   MMMMMMMMMMMMMMMMyoNNNMMM+.   MMMMMMMM  %s"
-"${c1}    MMNMMMNNMMMMMNM+ mhsMNyyyyMNMMMMsMM   %s"
-"${c1}                                          %s")
+"${c1}            .MMM..:MMMMMMM                 %s"
+"${c1}           MMMMMMMMMMMMMMMMMM              %s"
+"${c1}           MMMMMMMMMMMMMMMMMMMM.           %s"
+"${c1}          MMMMMMMMMMMMMMMMMMMMMM           %s"
+"${c1}         ,MMMMMMMMMMMMMMMMMMMMMM:          %s"
+"${c1}         MMMMMMMMMMMMMMMMMMMMMMMM          %s"
+"${c1}   .MMMM'  MMMMMMMMMMMMMMMMMMMMMM          %s"
+"${c1}  MMMMMM    \`MMMMMMMMMMMMMMMMMMMM.         %s"
+"${c1} MMMMMMMM      MMMMMMMMMMMMMMMMMM .        %s"
+"${c1} MMMMMMMMM.       \`MMMMMMMMMMMMM' MM.      %s"
+"${c1} MMMMMMMMMMM.                     MMMM     %s"
+"${c1} \`MMMMMMMMMMMMM.                 ,MMMMM.   %s"
+"${c1}  \`MMMMMMMMMMMMMMMMM.          ,MMMMMMMM.  %s"
+"${c1}     MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM  %s"
+"${c1}       MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM:  %s"
+"${c1}          MMMMMMMMMMMMMMMMMMMMMMMMMMMMMM   %s"
+"${c1}             \`MMMMMMMMMMMMMMMMMMMMMMMM:    %s"
+"${c1}                 \`\`MMMMMMMMMMMMMMMMM'      %s")
 		;;
 
 		"Frugalware")


### PR DESCRIPTION
Red Hat recently (May 2019) updated its official logo and brand standards, and the new logo is now a slightly different shaped fedora _without_ the shadowman figure beneath it.

You can see the new logo here: https://www.redhat.com/en/about/brand/standards

This PR just swaps the old logo with a representation of the new logo. I used an online image-to-ASCII generator with Red Hat's new logo and then cleaned up some bits by hand.

<img width="788" alt="Screen Shot 2019-05-08 at 1 05 23 PM" src="https://user-images.githubusercontent.com/1472326/57393855-0126e180-7192-11e9-8b16-e4c9561f33f3.png">