### PR TITLE
Fixed SailfishOS and openSUSE Tumbleweed detection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -898,6 +898,7 @@ detectdistro () {
 					fi
 
 					# Hotfixes
+                    [[ "${distro}" == "Opensuse-tumbleweed" ]] && distro="openSUSE" && distro_more="Tumbleweed"
 					[[ "${distro}" == "Opensuse-leap" ]] && distro="openSUSE"
 					[[ "${distro}" == "void" ]] && distro="Void Linux"
 					[[ "${distro}" == "evolveos" ]] && distro="Evolve OS"

--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -6273,17 +6273,6 @@ if [[ "$overrideDisplay" ]]; then
 	IFS=$OLDIFS
 fi
 
-# Check for android
-if [[ -f /system/build.prop  && "${distro}" != "SailfishOS" ]]; then
-	distro="Android"
-	detectmem
-	detectuptime
-	detectkernel
-	detectdroid
-	infoDisplay
-	exit 0
-fi
-
 for i in "${display[@]}"; do
 	if [[ -n "$i" ]]; then
 		if [[ $i =~ wm ]]; then
@@ -6300,6 +6289,17 @@ for i in "${display[@]}"; do
 		fi
 	fi
 done
+
+# Check for android
+if [[ -f /system/build.prop  && "${distro}" != "SailfishOS" ]]; then
+    distro="Android"
+    detectmem
+    detectuptime
+    detectkernel
+    detectdroid
+    infoDisplay
+    exit 0
+fi
 
 if [ "$gpu" = 'Not Found' ] ; then
 	DetectIntelGPU


### PR DESCRIPTION
Quick explanation:

`if [[ -f /system/build.prop  && "${distro}" != "SailfishOS" ]]; then`

 distro is empty as you are detecting distro below (whoever did that is genius)

Also somebody fixed leap when lsb_release is not installed but forgot about tumbleweed ¯\_(ツ)_/¯