### PR TITLE
Fix support for GuixSD

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1340,7 +1340,7 @@ detectpkgs () {
 		'NixOS')
 			pkgs=$(ls -d -1 /nix/store/*/ | wc -l) ;;
 		'GuixSD')
-			pkgs=$(ls -d -1 /guix/store/*/ | wc -l) ;;
+			pkgs=$(ls -d -1 /gnu/store/*/ | wc -l) ;;
 		'ALDOS'|'Fedora'|'Fux'|'Korora'|'BLAG'|'Chapeau'|'openSUSE'|'SUSE Linux Enterprise'|'Red Hat Enterprise Linux'| \
 		'ROSA'|'Oracle Linux'|'Scientific Linux'|'EuroLinux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'| \
 		'Red Star OS'|'blackPanther OS'|'Amazon Linux')
@@ -5151,7 +5151,7 @@ asciiText () {
 "${c1} ??                                  ?I %s"
 "${c1}  ??I?   I??N              ${c2}???    ${c1}????  %s"
 "${c1}   ?III7${c2}???????          ??????${c1}7III?Z   %s"
-"${c1}     OI77\$${c2}?????         ?????${c1}$77II      %s"
+"${c1}     OI77\$${c2}?????         ?????${c1}$77IIII      %s"
 "${c1}           ?????        ${c2}????            %s"
 "${c1}            ???ID      ${c2}????             %s"
 "${c1}             IIII     ${c2}+????             %s"


### PR DESCRIPTION
7bcf8b5 was merged two years ago, and since then, GuixSD has
transitioned towards using '/gnu/store' rather than '/guix/store' as the
store directory. Additionally, this patch fixes alignment with the logo
used for GuixSD.