### PR TITLE
Fix docker container virtual volume detect error

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1694,7 +1694,7 @@ detectdisk () {
 		elif [[ "${distro}" == "Mac OS X" ]]; then
 			totaldisk=$(df -H / 2>/dev/null | tail -1)
 		else
-			totaldisk=$(df -h -x aufs -x tmpfs --total 2>/dev/null | tail -1)
+			totaldisk=$(df -h -x aufs -x tmpfs -x overlay --total 2>/dev/null | tail -1)
 		fi
 		disktotal=$(awk '{print $2}' <<< "${totaldisk}")
 		diskused=$(awk '{print $3}' <<< "${totaldisk}")


### PR DESCRIPTION
The latest version has a Disk bug. When I use the docker container, the service can create a virtual volume mount on the system. such as:

```bash
Filesystem      Size  Used Avail Use% Mounted on
udev            480M     0  480M   0% /dev
/dev/vda1        39G  3.4G   33G  10% /
overlay          39G  3.4G   33G  10% /var/lib/docker/overlay2/0783f3003459bdfaf9f0fa64027ed9072f55054d53303a8379928e93f5e40594/merged
overlay          39G  3.4G   33G  10% /var/lib/docker/overlay2/cca6b1ce109fbdbb46223f067bd32eff1138ad68609cb7d87f1241c66f9592cc/merged
overlay          39G  3.4G   33G  10% /var/lib/docker/overlay2/8dd3289e8f39fc33b73d825a842a3e48f0ca8b433870a71f93d3e3718ef9b7f5/merged
overlay          39G  3.4G   33G  10% /var/lib/docker/overlay2/bc9fd971627673bd8b839fd2599ecdfb3adb80621ca6e105b3648d0312b80380/merged
total           192G   17G  165G  10% -
```

So the screenFetch display an error disk data. such as:

```bash
         _,met$$$$$gg.           root@domain.com
      ,g$$$$$$$$$$$$$$$P.        OS: Debian 10 buster
    ,g$$P""       """Y$$.".      Kernel: x86_64 Linux 4.19.0-5-amd64
   ,$$P'              `$$$.      Uptime: 2d 2h 9m
  ',$$P       ,ggs.     `$$b:    Packages: 401
  `d$$'     ,$P"'   .    $$$     Shell: bash 5.0.3
   $$P      d$'     ,    $$P     Disk: 17G / 192G (10%)
   $$:      $$.   -    ,d$$'     CPU: Intel Xeon E5-2682 v4 @ 2.5GHz
   $$\;      Y$b._   _,d$P'      GPU: Cirrus Logic GD 5446
   Y$$.    `.`"Y$$$$P"'          RAM: 466MiB / 987MiB
   `$$b      "-.__              
    `Y$$                        
     `Y$$.                      
       `$$b.                    
         `Y$$b.                 
            `"Y$b._             
                `"""" 
```

But in fact, this VPS only has a 40Gb disk.

After this fix

```bash
         _,met$$$$$gg.           root@domain.com
      ,g$$$$$$$$$$$$$$$P.        OS: Debian 10 buster
    ,g$$P""       """Y$$.".      Kernel: x86_64 Linux 4.19.0-5-amd64
   ,$$P'              `$$$.      Uptime: 2d 2h 13m
  ',$$P       ,ggs.     `$$b:    Packages: 401
  `d$$'     ,$P"'   .    $$$     Shell: bash 5.0.3
   $$P      d$'     ,    $$P     Disk: 3.4G / 39G (10%)
   $$:      $$.   -    ,d$$'     CPU: Intel Xeon E5-2682 v4 @ 2.5GHz
   $$\;      Y$b._   _,d$P'      GPU: Cirrus Logic GD 5446
   Y$$.    `.`"Y$$$$P"'          RAM: 466MiB / 987MiB
   `$$b      "-.__              
    `Y$$                        
     `Y$$.                      
       `$$b.                    
         `Y$$b.                 
            `"Y$b._             
                `"""" 
```

