### PR TITLE
Removed backslash in awk command.

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1600,7 +1600,7 @@ detectgpu () {
 	elif [[ "${distro}" == "OpenBSD" ]]; then
 		gpu=$(glxinfo 2> /dev/null | awk '/OpenGL renderer string/ { sub(/OpenGL renderer string: /,""); print }')
 	elif [[ "${distro}" == "Mac OS X" ]]; then
-		gpu=$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {print $2}' | awk '{ printf "%s / ", $0 }' | sed -e 's/\/ $//g')
+		gpu=$(system_profiler SPDisplaysDataType | awk -F': ' '/^ *Chipset Model:/ {print $2}' | awk '{ printf "%s / ", $0 }' | sed -e 's/\/ $//g')
 	elif [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" ]]; then
 		gpu=$(wmic path Win32_VideoController get caption | sed -n '2p')
 	elif [[ "${distro}" == "Haiku" ]]; then


### PR DESCRIPTION
I don't know how to link this to issue #627 .

For me, it fixed the warning
```
awk: cmd. line:1: warning: regexp escape sequence `\ ' is not a known regexp operator
```
