### PR TITLE
OpenBSD disk fix and kernel line improvement

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1271,7 +1271,7 @@ detecthost () {
 # Kernel Version Detection - Begin
 detectkernel () {
 	if [[ "$distro" == "OpenBSD" ]]; then
-		kernel=$(sysctl kern.version|awk -F'[ =:]' 'NR==1{print $3" "$4" "$5}')
+		kernel=$(uname -a | cut -f 3- -d ' ')
 	else
 		# compatibility for older versions of OS X:
 		kernel=$(uname -m && uname -sr)
@@ -1702,8 +1702,12 @@ DetectIntelGPU() {
 detectdisk () {
 	diskusage="Unknown"
 	if type -p df >/dev/null 2>&1; then
-		if [[ "${distro}" =~ (Free|Net|Open|DragonFly)BSD ]]; then
+		if [[ "${distro}" =~ (Free|Net|DragonFly)BSD ]]; then
 			totaldisk=$(df -h -c 2>/dev/null | tail -1)
+		elif [[ "${distro}" == "OpenBSD" ]]; then
+			totaldisk=$(df -Pk 2> /dev/null | awk '
+				/^\// {total+=$2; used+=$3; avail+=$4}
+				END{printf("total %.1fG %.1fG %.1fG %d%%\n", total/1048576, used/1048576, avail/1048576, used*100/total)}')
 		elif [[ "${distro}" == "Mac OS X" ]]; then
 			totaldisk=$(df -H / 2>/dev/null | tail -1)
 		else


### PR DESCRIPTION
Hi,

This OpenBSD-specific PR contains: 

### A disk fix

OpenBSD `df` has no `-c` option, and has no equivalent. The disk line stays empty.

The default case also assumes `df` is GNU `df`. Instead, i'm proposing here a more [posix-compliant](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/df.html) version, that even works against GNU `df` and `awk`. 

Numbers are slightly different (see captures against GNU `df`) probably due to different rounding methods. I've limited the use case to OpenBSD anyway.

### A kernel line improvement

Before:
`6.6 (GENERIC.MP) #356` (no architecture mention)

After: 
`6.6 GENERIC.MP#356 amd64`

![capture_2019-10-12_040719_25344](https://user-images.githubusercontent.com/41287367/66693209-d5f76f80-eca6-11e9-839d-efc6f6be40e3.png)
![capture_2019-10-12_041127_19401](https://user-images.githubusercontent.com/41287367/66693210-d6900600-eca6-11e9-8960-04a52e3551fe.png)

