### PR TITLE
Fixed comma character in macos resolution

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1901,7 +1901,7 @@ detectres () {
 	if [[ ${distro} == "Mac OS X" ]]; then
 		xResolution=$(system_profiler SPDisplaysDataType | awk '/Resolution:/ {print $2"x"$4" "}')
 		if [[ "$(echo "$xResolution" | wc -l)" -ge 1 ]]; then
-			xResolution=$(echo "$xResolution" | tr "\\n" "," | sed 's/\(.*\),/\1/')
+			xResolution=$(echo "$xResolution" | tr " \\n" ", " | sed 's/\(.*\),/\1/')
 		fi
 	elif [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" ]]; then
 		xResolution=$(wmic path Win32_VideoController get CurrentHorizontalResolution,CurrentVerticalResolution | awk 'NR==2 {print $1"x"$2}')


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5730766/70399296-04819480-1a23-11ea-9f4f-da99fa109456.png)
After:
![image](https://user-images.githubusercontent.com/5730766/70399315-2bd86180-1a23-11ea-9ee5-9db98ff98736.png)
