### PR TITLE
Fix total disk size for WSL based distros

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1718,7 +1718,7 @@ detectdisk () {
 		elif [[ "${distro}" == "Mac OS X" ]]; then
 			totaldisk=$(df -H / 2>/dev/null | tail -1)
 		else
-			totaldisk=$(df -h -x aufs -x tmpfs -x overlay --total 2>/dev/null | tail -1)
+			totaldisk=$(df -h -x aufs -x tmpfs -x overlay -x drvfs --total 2>/dev/null | tail -1)
 		fi
 		disktotal=$(awk '{print $2}' <<< "${totaldisk}")
 		diskused=$(awk '{print $3}' <<< "${totaldisk}")


### PR DESCRIPTION
As mentioned in https://github.com/KittyKatt/screenFetch/issues/660 here is the fix for screenfetch on WSL doubling the total disk size.

For more infos on DrvFS being used only on WSL: https://devblogs.microsoft.com/commandline/chmod-chown-wsl-improvements/