### PR TITLE
Add model detection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -48,6 +48,7 @@ valid_display=(
 		'distro'
 		'host'
 		'kernel'
+		'model'
 		'uptime'
 		'pkgs'
 		'shell'
@@ -64,6 +65,7 @@ valid_display=(
 display=(
 		'distro'
 		'host'
+		'model'
 		'kernel'
 		'uptime'
 		'pkgs'
@@ -1274,6 +1276,21 @@ detecthost () {
 
 # Find Number of Running Processes
 # processnum="$(( $( ps aux | wc -l ) - 1 ))"
+
+# Model Detection - Begin
+detectmodel () {
+	model="Unknown"
+	if [[ "$distro" == "Raspbian" ]]; then
+		model=$(cat /sys/firmware/devicetree/base/model | tr '\0' '\n')
+	elif [[ -f /sys/devices/virtual/dmi/id/sys_vendor ]]; then
+		sys_vendor=$(cat /sys/devices/virtual/dmi/id/sys_vendor)
+		product_name=$(cat /sys/devices/virtual/dmi/id/product_name)
+		if [[ "${sys_vendor,,}" != "system manufacturer" && "${product_name,,}" != "system product name" ]]; then
+			model="$sys_vendor $product_name"
+		fi
+	fi
+}
+# Model Detection - End
 
 # Kernel Version Detection - Begin
 detectkernel () {
@@ -6169,6 +6186,11 @@ infoDisplay () {
 				fi
 			fi
 			out_array=( "${out_array[@]}" "$mydistro$wsl" )
+			((display_index++))
+		fi
+		if [[ "${display[@]}" =~ "model" && "${model}" != "Unknown" ]]; then
+			mymodel=$(echo -e "$labelcolor Model:$textcolor $model")
+			out_array=( "${out_array[@]}" "$mymodel" )
 			((display_index++))
 		fi
 		if [[ "${display[@]}" =~ "kernel" ]]; then


### PR DESCRIPTION
* Currently detects the model of Raspberry Pi boards on raspbian, and
  also tries to detect manufacturer/model from
  /sys/devices/virtual/dmi/id/[sys_vendor,product_name] if they exist