### PR TITLE
fix e16 theme detection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2472,7 +2472,7 @@ detectwmtheme () {
 				fi
 			;;
 			'E16')
-				Win_theme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")"
+				Win_theme="$(awk -F"= " '/theme.name/ {print $2}' $HOME/.e16/e_config--*.cfg)"
 			;;
 			'E17'|'Enlightenment')
 				if [ "$(which eet 2>/dev/null)" ]; then


### PR DESCRIPTION
Fix e16 theme detection.  On some systems, the active config file is different.  Mine shows `$HOME/.e16/e_config--0.cfg` on the main desktop, which differs from the `0.0` in the repo.  But also, if using a different X11 desktop number, the numeric value may be different.