### PR TITLE
fix tcsh shell detection by looking at /proc/$PPID/exe

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1854,7 +1854,7 @@ detectshell () {
 			shell_type="BusyBox"
 		else
 			if [[ "${OSTYPE}" =~ "linux" ]]; then
-				shell_type=$(tr '\0' '\n' </proc/$PPID/cmdline | head -1)
+				shell_type=$(realpath /proc/$PPID/exe | awk -F'/' '{print $NF}')
 			elif [[ "${distro}" =~ "BSD" ]]; then
 				shell_type=$(ps -p $PPID -o command | tail -1)
 			else


### PR DESCRIPTION
Looking at `/proc/$PPID/cmdline` gave incorrect results of `csh` instead of `tcsh` on my debian system.  This change uses `/proc/$PPID/exec` instead, which seems to be more reliable.  Tested with bash and dash as well, successfully.