### PR TITLE
add generic support for aarch64 CPUs

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1533,6 +1533,10 @@ detectcpu () {
 						2964) model="IBM z13" ;;
 						   *) model="IBM S/390 machine type $machine" ;;
 					esac
+				elif [[ "$arch" == "aarch64" ]]; then
+					cpu_vendor=$(lscpu | grep ^Vendor | sed 's/^.*://g; s/ //g; s/,/\n/g')
+					cpu=$(lscpu | grep ^Model\ name: | sed 's/^.*://g; s/ //g; s/,/\n/g')
+					cpu="${cpu_vendor} ${cpu}"
 				else
 					model="Unknown"
 				fi


### PR DESCRIPTION
[Because of reasons](http://suihkulokki.blogspot.com/2018/02/making-sense-of-proccpuinfo-on-arm.html), CPU info does not exist in `/proc/cpuinfo` in a human-friendly format on Linux/aarch64. Instead, `lscpu` (from [common Linux utils](https://en.wikipedia.org/wiki/Util-linux)) maintains a translation table. 

Tested on a SolidRun HoneyComb LX2K, AWS a1.medium (Amazon custom chip), and a packet.net c2.large.arm.

LX2K with patch:
![screenfetch-seras](https://user-images.githubusercontent.com/147783/82112846-da38af00-9705-11ea-9f1e-37e657d96ec3.png)

LX2K without:
![screenfetch-stock-fedora](https://user-images.githubusercontent.com/147783/82112858-e886cb00-9705-11ea-9646-e696b61bbfe3.png)

AWS (Amazon Linux appears to be running a old version of `lscpu` that does not contain the necessary info)
![screenfetch-aws](https://user-images.githubusercontent.com/147783/82112865-f3d9f680-9705-11ea-9aa0-2bf0ceef9671.png)

Packet (without and then with):
![packet-c2-screenfetch](https://user-images.githubusercontent.com/147783/82112879-1b30c380-9706-11ea-80f3-94acead7f794.png)
