### PR TITLE
Improve package counting for NixOS

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1368,7 +1368,7 @@ detectpkgs () {
 		'Gentoo'|'Sabayon'|'Funtoo'|'Kogaion')
 			pkgs=$(ls -d /var/db/pkg/*/* | wc -l) ;;
 		'NixOS')
-			pkgs=$(ls -d -1 /nix/store/*/ | wc -l) ;;
+			pkgs=$(nix path-info -r /run/current-system | wc -l) ;;
 		'Guix System')
 			pkgs=$(guix package --list-installed | wc -l) ;;
 		'ALDOS'|'Fedora'|'Fux'|'Korora'|'BLAG'|'Chapeau'|'openSUSE'|'SUSE Linux Enterprise'|'Red Hat Enterprise Linux'| \


### PR DESCRIPTION
Strictly speaking, question of "number of packages" for NixOS is somewhat nonsensical (there are no packages in NixOS, and this was pointed out in https://github.com/KittyKatt/screenFetch/pull/220).

However, I believe even then counting a number of derivations in a current system makes more sense than counting number of derivations resolving to directories ever installed.