### PR TITLE
Added AlterLinux logo

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -358,7 +358,7 @@ detectColors () {
 	my_hcolor=$(colorNumberToCode "${my_hcolor}")
 }
 
-supported_distros="ALDOS, Alpine Linux, Amazon Linux, Antergos, Arch Linux (Old and Current Logos), ArcoLinux, Artix Linux, \
+supported_distros="ALDOS, Alter Linux, Alpine Linux, Amazon Linux, Antergos, Arch Linux (Old and Current Logos), ArcoLinux, Artix Linux, \
 blackPanther OS, BLAG, BunsenLabs, CentOS, Chakra, Chapeau, Chrome OS, Chromium OS, CrunchBang, CRUX, \
 Debian, Deepin, DesaOS,Devuan, Dragora, DraugerOS, elementary OS, EuroLinux, Evolve OS, Sulin, Exherbo, Fedora, Frugalware, Fuduntu, Funtoo, \
 Fux, Gentoo, gNewSense, Guix System, Hyperbola GNU/Linux-libre, januslinux, Jiyuu Linux, Kali Linux, KaOS, KDE neon, Kogaion, Korora, \
@@ -573,6 +573,10 @@ detectdistro () {
 						fi
 						if grep -q -i 'obrevenge' /etc/os-release; then
 							distro="OBRevenge"
+							distro_release="n/a"
+						fi
+						if grep -q -i 'Alter' /etc/os-release; then
+							distro="Alter Linux"
 							distro_release="n/a"
 						fi
 					fi
@@ -929,6 +933,7 @@ detectdistro () {
 					[[ "${distro}" == "Sulin" ]] && distro="Sulin"
 					[[ "${distro}" == "antergos" ]] && distro="Antergos"
 					[[ "${distro}" == "logos" ]] && distro="Logos"
+					[[ "${distro}" == "alter" || "${distro}" == "Alter" ]] && distro="Alter Linux"
 					[[ "${distro}" == "Arch" || "${distro}" == "Archarm" || "${distro}" == "archarm" ]] && distro="Arch Linux"
 					[[ "${distro}" == "elementary" ]] && distro="elementary OS"
 					[[ "${distro}" == "Fedora" && -d /etc/qubes-rpc ]] && distro="qubes" # Inner VM
@@ -1156,6 +1161,7 @@ detectdistro () {
 	case $distro in
 		aldos) distro="ALDOS";;
 		alpine) distro="Alpine Linux" ;;
+		alter*linux|alter) distro="Alter Linux" ;;
 		amzn|amazon|amazon*linux) distro="Amazon Linux" ;;
 		antergos) distro="Antergos" ;;
 		arch*linux*old) distro="Arch Linux - Old" ;;
@@ -1346,7 +1352,7 @@ detectpkgs () {
 	case "${distro}" in
 		'Alpine Linux') pkgs=$(apk info | wc -l) ;;
 		'Arch Linux'|'ArcoLinux'|'Parabola GNU/Linux-libre'|'Hyperbola GNU/Linux-libre'|'Chakra'|'Manjaro'|'Antergos'| \
-		'Netrunner'|'KaOS'|'Obarun'|'SwagArch'|'OBRevenge'|'Artix Linux'|'EndeavourOS')
+		'Netrunner'|'KaOS'|'Obarun'|'SwagArch'|'OBRevenge'|'Artix Linux'|'EndeavourOS'|'AlterLinux')
 			pkgs=$(pacman -Qq | wc -l) ;;
 		'Chrome OS')
 			if [ -d "/usr/local/lib/crew/packages" ]; then
@@ -3249,7 +3255,38 @@ asciiText () {
 "${c1} ooooooooo-                 ${c2}.-oooooooooo.${c1}%s"   
 "${c1}ooooooooo.                     ${c2}-ooooooooo${c1}%s")
 		;;
-		
+
+		"Alter Linux"|"Alter")
+			if [[ "$no_color" != "1" ]]; then
+				c1=$(getColor 'light cyan') # Light
+				c2=$(getColor 'cyan') # Dark
+			fi
+			if [ -n "${my_lcolor}" ]; then c1="${my_lcolor}"; c2="${my_lcolor}"; fi
+			startline="1"
+			logowidth="38"
+			fulloutput=(
+"${c1}                      &,                       "
+"${c1}                    ^WWWw                      %s"
+"${c1}                   !wwwwww                     %s"
+"${c1}                  !wwwwwwww                    %s"
+"${c1}                 #wwwwwwwwww                   %s"
+"${c1}                @wwwwwwwwwwww                  %s"
+"${c1}               wwwwwwwwwwwwwww                 %s"
+"${c1}              wwwwwwwwwwwwwwwww                %s"
+"${c1}             wwwwwwwwwwwwwwwwwww               %s"
+"${c1}            wwwwwwwwwwwwwwwwwwww,              %s"
+"${c1}           w~1i.wwwwwwwwwwwwwwwww,             %s"
+"${c1}         3~:~1lli.wwwwwwwwwwwwwwww.            %s"
+"${c1}        :~~:~?ttttzwwwwwwwwwwwwwwww            %s"
+"${c1}       #<~:~~~~?llllltO-.wwwwwwwwwww           %s"
+"${c1}      #~:~~:~:~~?ltlltlttO-.wwwwwwwww          %s"
+"${c1}     @~:~~:~:~:~~(zttlltltlOda.wwwwwww         %s"
+"${c1}    @~:~~: ~:~~:~:(zltlltlO    a,wwwwww        %s"
+"${c1}   8~~:~~:~~~~:~~~~_1ltltu          ,www       %s"
+"${c1}  5~~:~~:~~:~~:~~:~~~_1ltq             N,,     %s"
+"${c1} g~:~~:~~~:~~:~~:~:~~~~1q                N,    %s" )
+		;;
+
 		"Mint")
 			if [[ "$no_color" != "1" ]]; then
 				c1=$(getColor 'white') # White
@@ -6107,7 +6144,7 @@ infoDisplay () {
 	[[ "${asc_distro}" ]] && myascii="${asc_distro}"
 	case ${myascii} in
 		"Alpine Linux"|"Arch Linux - Old"|"ArcoLinux"|"blackPanther OS"|"Fedora"|"Korora"|"Chapeau"|"Mandriva"|"Mandrake"| \
-		"Chakra"|"ChromeOS"|"Sabayon"|"Slackware"|"Mac OS X"|"Trisquel"|"Kali Linux"|"Jiyuu Linux"|"Antergos"| \
+		"Chakra"|"ChromeOS"|"Sabayon"|"Slackware"|"Mac OS X"|"Trisquel"|"Kali Linux"|"Jiyuu Linux"|"Antergos"|"Alter Linux"| \
 		"KaOS"|"Logos"|"gNewSense"|"Netrunner"|"NixOS"|"SailfishOS"|"Qubes OS"|"Kogaion"|"PCLinuxOS"| \
 		"Obarun"|"Siduction"|"Solus"|"SwagArch"|"Parrot Security"|"Zorin OS")
 			labelcolor=$(getColor 'light blue')


### PR DESCRIPTION
I have added the AlterLinux logo.
[AlterLinux](https://github.com/FascodeNet/alterlinux) is a derivative of ArchLinux developed in Japan.
The latest neofetch already has a logo added, but screenfetch did not.
I couldn't find a specific coding convention, but I wrote the code as much as possible, like any other.
I'm very excited and nervous about pulling requests for a large project. :)