### PR TITLE
Detect CentOS Stream correctly

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -833,6 +833,9 @@ detectdistro () {
 					fi
 					;;
 			esac
+			if [[ "${distro_detect}" =~ "CentOSStream" ]]; then
+				distro="CentOS Stream"
+			fi
 			if [[ "${distro_detect}" =~ "RedHatEnterprise" ]]; then
 				distro="Red Hat Enterprise Linux"
 			fi
@@ -1171,6 +1174,7 @@ detectdistro () {
 		blag) distro="BLAG" ;;
 		bunsenlabs) distro="BunsenLabs" ;;
 		centos) distro="CentOS" ;;
+		centos*stream) distro="CentOS Stream" ;;
 		chakra) distro="Chakra" ;;
 		chapeau) distro="Chapeau" ;;
 		chrome*|chromium*) distro="Chrome OS" ;;
@@ -1378,7 +1382,7 @@ detectpkgs () {
 		'Guix System')
 			pkgs=$(guix package --list-installed | wc -l) ;;
 		'ALDOS'|'Fedora'|'Fux'|'Korora'|'BLAG'|'Chapeau'|'openSUSE'|'SUSE Linux Enterprise'|'Red Hat Enterprise Linux'| \
-		'ROSA'|'Oracle Linux'|'Scientific Linux'|'EuroLinux'|'CentOS'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'| \
+		'ROSA'|'Oracle Linux'|'Scientific Linux'|'EuroLinux'|'CentOS'|'CentOS Stream'|'Mandriva'|'Mandrake'|'Mageia'|'Mer'|'SailfishOS'|'PCLinuxOS'|'Viperr'|'Qubes OS'| \
 		'Red Star OS'|'blackPanther OS'|'Amazon Linux')
 			pkgs=$(rpm -qa | wc -l) ;;
 		'Void Linux')
@@ -5103,7 +5107,7 @@ asciiText () {
 "${c1}                    .SSS....S..    %s")
 		;;
 
-		"CentOS")
+		"CentOS"|"CentOS Stream")
 			if [[ "$no_color" != "1" ]]; then
 				c1=$(getColor 'yellow')
 				c2=$(getColor 'light green')
@@ -6146,7 +6150,7 @@ infoDisplay () {
 		"NetBSD"|"Amazon Linux"|"Proxmox VE")
 			labelcolor=$(getColor 'orange')
 		;;
-		"CentOS")
+		"CentOS"|"CentOS Stream")
 			labelcolor=$(getColor 'yellow')
 		;;
 		"Hyperbola GNU/Linux-libre"|"PureOS"|*)


### PR DESCRIPTION
Due to the output of "lsb_release -si" of CentOS Stream is <code>CentOSStream</code> rather than <code>CentOS</code>.