### PR TITLE
Fix for Issue 704(Languages with longer words for memory)

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1835,7 +1835,7 @@ detectmem () {
 		#done
 		#usedmem=$((usedmem / 1024))
 		#totalmem=$((totalmem / 1024))
-		mem=$(free -b | awk 'NR==2{print $2"-"$7}')
+		mem=$(free -b | awk -F ':' 'NR==2{print $2}' | awk '{print $1"-"$6}')
 		usedmem=$((mem / 1024 / 1024))
 		totalmem=$((${mem//-*} / 1024 / 1024))
 	fi


### PR DESCRIPTION
When the word for "mem" gets long, it causes `free -b` to not have whitespace before the total memory which breaks the awk which splits the line.

This is a simple fix that splits the line twice, once on the `:` and then again on the remainder of the line.