### PR TITLE
Fix the memory calculation BUG of 1840 lines

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1841,9 +1841,9 @@ detectmem () {
 		#done
 		#usedmem=$((usedmem / 1024))
 		#totalmem=$((totalmem / 1024))
-		mem=$(free -b | awk -F ':' 'NR==2{print $2}' | awk '{print $1"-"$6}')
-		usedmem=$((mem / 1024 / 1024))
-		totalmem=$((${mem//-*} / 1024 / 1024))
+		mem=$(free  | awk 'NR==2{print $2"-"$7}')
+		usedmem=$((mem / 1024 ))
+		totalmem=$((${mem//-*} / 1024 ))
 	fi
 	mem="${usedmem}MiB / ${totalmem}MiB"
 	verboseOut "Finding current RAM usage...found as '$mem'"


### PR DESCRIPTION
I find the calculation result of ‘men’ here is wrong in the Chinese version, because it cannot correctly identify the position of free-b, so I modified it. I tested it on openSUSE Tumbleweed in Chinese and English, and now ‘men’ can be calculated correctly. 
ERROR：/usr/bin/screenfetch: Line 1802: 1921671168-: Syntax error: operand required (error symbol is "-")
Initial：	
		#mem=$(free -b | awk -F ':' 'NR==2{print $2}' | awk '{print $1"-"$6}')
		#usedmem=$((mem / 1024 / 1024))
		#totalmem=$((${mem//-*} / 1024 / 1024))
Edited：
		mem=$(free  | awk 'NR==2{print $2"-"$7}')
		usedmem=$((mem / 1024 ))
		totalmem=$((${mem//-*} / 1024 ))