### PR TITLE
Change the source of obtaining memory information to cat /proc/meminfo instead of free -b

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1841,9 +1841,9 @@ detectmem () {
 		#done
 		#usedmem=$((usedmem / 1024))
 		#totalmem=$((totalmem / 1024))
-		mem=$(free -b | awk -F ':' 'NR==2{print $2}' | awk '{print $1"-"$6}')
-		usedmem=$((mem / 1024 / 1024))
-		totalmem=$((${mem//-*} / 1024 / 1024))
+		mem=$(cat /proc/meminfo | awk 'NR==1{print $2}')"-"$(cat /proc/meminfo | awk 'NR==3{print $2}')
+		usedmem=$((mem / 1024))
+		totalmem=$((${mem//-*} / 1024))
 	fi
 	mem="${usedmem}MiB / ${totalmem}MiB"
 	verboseOut "Finding current RAM usage...found as '$mem'"


### PR DESCRIPTION
When screenfetch gets memory information, awk is used to calculate the difference between the second column and the seventh column of the second row output by the free - b command. However, in the Chinese environment, the first column and the second column of free - b are not separated by spaces, resulting in one missing column and an error will be reported.

I think it's about the translation of free package. The blank space was removed in Chinese translation. But after consulting members of arch Linux group, they suggested that it's better to get memory information from /proc/meminfo instead of using the free -b command