### PR TITLE
Update homebrew path for Apple Silicon

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1439,7 +1439,13 @@ detectpkgs () {
 				pkgs=$((pkgs + (port_pkgs - offset)))
 			fi
 			if type -p brew >/dev/null 2>&1; then
-				brew_pkgs=$(ls -1 /usr/local/Cellar/ | wc -l)
+				# Homebrew in Apple Silicon installs to a different path than Intel Macs
+				if [[ $kernel == *"arm64 Darwin"* ]]; then
+					homebrew_path="/opt/homebrew/Cellar/"
+				else
+					homebrew_path="/usr/local/Cellar/"
+			  	fi
+				brew_pkgs=$(ls -1 $homebrew_path | wc -l)
 				pkgs=$((pkgs + brew_pkgs))
 			fi
 			if type -p pkgin >/dev/null 2>&1; then


### PR DESCRIPTION
When using `./screenfetch-dev` on my Apple Silicon Mac (Mac mini (M1, 2020)), there was a line of output that errors out with the following text.

```
ls: /usr/local/Cellar/: No such file or directory
```

 The reason is because Homebrew, on the M1 platform, installs to /opt/homebrew/Cellar, rather than the /usr/local/Cellar.

https://apple.stackexchange.com/questions/410825/apple-silicon-port-all-homebrew-packages-under-usr-local-opt-to-opt-homebrew

This patch should resolve that.  Thanks!