### PR TITLE
ignore devtmpfs in disk space calculations

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1765,7 +1765,7 @@ detectdisk () {
 				totaldisk=$(df -H / 2>/dev/null | tail -1)
 			fi
 		else
-			totaldisk=$(df -h -x aufs -x tmpfs -x overlay -x drvfs --total 2>/dev/null | tail -1)
+			totaldisk=$(df -h -x aufs -x tmpfs -x overlay -x drvfs -x devtmpfs --total 2>/dev/null | tail -1)
 		fi
 		disktotal=$(awk '{print $2}' <<< "${totaldisk}")
 		diskused=$(awk '{print $3}' <<< "${totaldisk}")


### PR DESCRIPTION
Debian 11 uses `devtmpfs` which is not currently excluded. This PR excludes it.

```
jda@tangent:~/Projects/screenFetch$ df -hT -x zfs
Filesystem     Type      Size  Used Avail Use% Mounted on
udev           devtmpfs   63G     0   63G   0% /dev
tmpfs          tmpfs      13G  2.5M   13G   1% /run
/dev/nvme0n1p3 btrfs     1.9T   16G  1.8T   1% /
tmpfs          tmpfs      63G  116K   63G   1% /dev/shm
tmpfs          tmpfs     5.0M  4.0K  5.0M   1% /run/lock
/dev/nvme0n1p1 vfat      476M   20M  456M   5% /boot/efi
tmpfs          tmpfs      13G   48K   13G   1% /run/user/1000
jda@tangent:~/Projects/screenFetch$ 
```