### PR TITLE
Fix detection of Kali Linux when lsb_release is not installed

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1226,7 +1226,7 @@ detectdistro () {
 		haiku) distro="Haiku" ;;
 		hyperbolagnu|hyperbolagnu/linux-libre|'hyperbola gnu/linux-libre'|hyperbola) distro="Hyperbola GNU/Linux-libre" ;;
 		januslinux) distro="januslinux" ;;
-		kali*linux) distro="Kali Linux" ;;
+		kali|kali*linux) distro="Kali Linux" ;;
 		kaos) distro="KaOS";;
 		kde*neon|neon) distro="KDE neon" ;;
 		kogaion) distro="Kogaion" ;;


### PR DESCRIPTION
When lsb_release is not available (eg. when running Kali Linux in a
container), detection is done based on the ID variable from the
os-release file.  For Kali Linux, this ID is simply 'kali'.

However screenfetch is looking for the glob 'kali*linux', so it doesn't
work:

```
  ┌──(like㉿kali)-[/work]
  └─# screenfetch -vvvvv
  :: Finding distro...found as 'kali '

  [...]

                               OS: kali
                               Kernel: xxx
           #####               Uptime: xxx
          #######              Packages: Unknown
          ##O#O##              Shell: xxx
          #######              Disk: xxx
        ###########            CPU: xxx
       #############           GPU: xxx
      ###############          RAM: xxx
      ################
     #################
   #####################
   #####################
     #################
```

Fixed with this commit.