### PR TITLE
Fix for grep warning about stray \

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2076,7 +2076,7 @@ detectde () {
 				elif dbus-send --print-reply --dest=org.freedesktop.DBus /org/freedesktop/DBus \
 					org.freedesktop.DBus.GetNameOwner string:org.gnome.SessionManager >/dev/null 2>&1 ; then
 					DE="GNOME"
-				elif xprop -root _DT_SAVE_MODE 2> /dev/null | grep -q -i ' = \"xfce4\"$'; then
+				elif xprop -root _DT_SAVE_MODE 2> /dev/null | grep -q -i ' = "xfce4"$'; then
 					DE="Xfce"
 				elif xprop -root 2> /dev/null | grep -q -i '^xfce_desktop_window'; then
 					DE="Xfce"


### PR DESCRIPTION
A recent change to grep has made this generate a warning. It's been showing up whenever screenfetch is executed. Fixed.

Closes gh-754