### PR TITLE
Fix layout corrupt in Cygwin and MSYS environments

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2472,7 +2472,7 @@ detectwmtheme () {
 			else
 				Blackbox_loc=$(reg query 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\WinLogon' /v 'Shell')
 			fi
-			Blackbox_loc="$(echo "${Blackbox_loc}" | sed 's/.*REG_SZ//' | sed -e 's/^[ \t]*//' | sed 's/.\{4\}$//')"
+			Blackbox_loc="$(echo "${Blackbox_loc}" | tr -d "\r" | sed 's/.*REG_SZ//' | sed -e 's/^[ \t]*//' | sed 's/.\{4\}$//')"
 			Win_theme=$(grep 'session.styleFile' "${Blackbox_loc}.rc" | sed 's/ //g' | sed 's/session\.styleFile://g' | sed 's/.*\\//g')
 		else
 			if [[ "${distro}" == "Msys" ]]; then
@@ -2480,7 +2480,7 @@ detectwmtheme () {
 			else
 				themeFile="$(reg query 'HKCU\Software\Microsoft\Windows\CurrentVersion\Themes' /v 'CurrentTheme')"
 			fi
-			Win_theme=$(echo "$themeFile" | awk -F"\\" '{print $NF}' | sed 's|\.theme$||')
+			Win_theme=$(echo "$themeFile" | tr -d "\r" | grep CurrentTheme | awk -F"\\" '{print $NF}' | sed 's|\.theme$||')
 		fi
 	else
 		case $WM in
@@ -6364,7 +6364,7 @@ infoDisplay () {
 			elif [[ "$distro" == "Cygwin" || "$distro" == "Msys" ]]; then
 				distro="$(wmic os get caption | sed 's/\r//g; s/[ \t]*$//g; 2!d')"
 				if [[ "$(wmic os get version | grep -o '^10\.')" == "10." ]]; then
-					distro="$distro (v$(wmic os get version | grep '^10\.' | tr -d ' '))"
+					distro="$distro (v$(wmic os get version | tr -d "\r" | grep '^10\.' | tr -d ' '))"
 				fi
 				sysArch=$(wmic os get OSArchitecture | sed 's/\r//g; s/[ \t]*$//g; 2!d')
 				mydistro=$(echo -e "$labelcolor OS:$textcolor $distro $sysArch")


### PR DESCRIPTION
This patch fixes #632 and #606.

Please refer `OS` section and `WM Theme` section of https://github.com/KittyKatt/screenFetch/issues/606#issuecomment-1399430320

## Expected (patched) behaviour in Cygwin
![](https://user-images.githubusercontent.com/11992915/213879546-6b7ad2cd-2e8f-46c3-9273-0ff9d523739d.png)

## Actual behaviour in Cygwin
![](https://user-images.githubusercontent.com/11992915/213879264-346214ac-d6e2-42d1-8926-abd2ea76e00c.png)