### PR TITLE
Add pacman if-branch for Git for Windows

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1469,10 +1469,20 @@ detectpkgs () {
 			fi
 		;;
 		'Msys')
-			pkgs=$(pacman -Qq | wc -l)
-			if [ -d "/c/ProgramData/chocolatey/lib" ]; then
-				chocopkgs=$(ls -1 /c/ProgramData/chocolatey/lib | wc -l)
-				pkgs=$((pkgs + chocopkgs))
+			# Git for Windows (Msys-based) does not have any package manager
+			if command -v pacman &> /dev/null; then
+				# for Msys
+				pkgs=$(pacman -Qq | wc -l)
+				if [ -d "/c/ProgramData/chocolatey/lib" ]; then
+					chocopkgs=$(ls -1 /c/ProgramData/chocolatey/lib | wc -l)
+					pkgs=$((pkgs + chocopkgs))
+				fi
+			else
+				# for Git for Windows
+				if [ -d "/c/ProgramData/chocolatey/lib" ]; then
+					chocopkgs=$(ls -1 /c/ProgramData/chocolatey/lib | wc -l)
+					pkgs="$pkgs + $chocopkgs" # shows "Unknown + 1234"
+				fi
 			fi
 		;;
 		'Haiku')


### PR DESCRIPTION
This patch fixes `pacman: command not found` issue in Git for Windows.

This PR is separated.

Please refer `Packages` section of https://github.com/KittyKatt/screenFetch/issues/606#issuecomment-1399430320

## Expected behaviour in Git for Bash
![image](https://user-images.githubusercontent.com/11992915/213907378-dcf33c49-fae0-4a10-b67c-433c6754da41.png)

## Actual behaviour in Git for Bash
![image](https://user-images.githubusercontent.com/11992915/213907341-4a58b178-3e46-4008-8ed0-3d52d2addda8.png)