### PR TITLE
Fix that RAM information cannot be read correctly when the system language is Chinese

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1847,7 +1847,7 @@ detectmem () {
 		#done
 		#usedmem=$((usedmem / 1024))
 		#totalmem=$((totalmem / 1024))
-		mem=$(free -b | awk -F ':' 'NR==2{print $2}' | awk '{print $1"-"$6}')
+		mem=$(free -b | awk -F '[:：]' 'NR==2{print $2}' | awk '{print $1"-"$6}')
 		usedmem=$((mem / 1024 / 1024))
 		totalmem=$((${mem//-*} / 1024 / 1024))
 	fi


### PR DESCRIPTION
Running screenFetch when the system language is Chinese will report an error. The reason is that the "free - b" separator is a Chinese colon when the system language is Chinese