### PR TITLE
Fix RAM information not displaying correctly

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1847,7 +1847,7 @@ detectmem () {
 		#done
 		#usedmem=$((usedmem / 1024))
 		#totalmem=$((totalmem / 1024))
-		mem=$(free -b | awk -F ':' 'NR==2{print $2}' | awk '{print $1"-"$6}')
+		mem=$(free -b | awk -F ':|：' 'NR==2{print $2}' | awk '{print $1"-"$6}')
 		usedmem=$((mem / 1024 / 1024))
 		totalmem=$((${mem//-*} / 1024 / 1024))
 	fi


### PR DESCRIPTION
When running screenfetch when the system language is Chinese, an error will be reported and RAM information cannot be displayed correctly. The reason is that when the system language is Chinese, the colon used to execute "free -b" output is a Chinese colon, and the characters cannot be correctly segmented.