### PR TITLE
Detect which awk to use

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -352,9 +352,9 @@ colorNumberToCode () {
 
 detectColors () {
 	my_colors=$(sed 's/^,/na,/;s/,$/,na/;s/,/ /' <<< "${OPTARG}")
-	my_lcolor=$(awk -F' ' '{print $1}' <<< "${my_colors}")
+	my_lcolor=$("${AWK}" -F' ' '{print $1}' <<< "${my_colors}")
 	my_lcolor=$(colorNumberToCode "${my_lcolor}")
-	my_hcolor=$(awk -F' ' '{print $2}' <<< "${my_colors}")
+	my_hcolor=$("${AWK}" -F' ' '{print $2}' <<< "${my_colors}")
 	my_hcolor=$(colorNumberToCode "${my_hcolor}")
 }
 
@@ -468,7 +468,22 @@ case $1 in
 	--version) displayVersion; exit 0;;
 esac
 
+# Detect which awk to use (unless already specified in environment)
+if [[ -z "${AWK}" ]]; then
+	for awk in awk gawk mawk; do
+		if command -v "${awk}" > /dev/null; then
+			AWK="${awk}"
+			break
+		fi
+	done
+fi
 
+if ! command -v "${AWK}" > /dev/null; then
+	errorOut "No awk interpreter available (AWK=\"${AWK}\")."
+	exit 1
+fi
+
+# Parse the rest of the flags (some of these functions require awk)
 while getopts ":hsu:evVEnLNtlS:A:D:o:c:d:pa:w:C:" flags; do
 	case $flags in
 		h) displayHelp; exit 0 ;;
@@ -619,8 +634,8 @@ detectdistro () {
 				"Debian")
 					if [[ -f /etc/crunchbang-lsb-release || -f /etc/lsb-release-crunchbang ]]; then
 						distro="CrunchBang"
-						distro_release=$(awk -F'=' '/^DISTRIB_RELEASE=/ {print $2}' /etc/lsb-release-crunchbang)
-						distro_codename=$(awk -F'=' '/^DISTRIB_DESCRIPTION=/ {print $2}' /etc/lsb-release-crunchbang)
+						distro_release=$("${AWK}" -F'=' '/^DISTRIB_RELEASE=/ {print $2}' /etc/lsb-release-crunchbang)
+						distro_codename=$("${AWK}" -F'=' '/^DISTRIB_DESCRIPTION=/ {print $2}' /etc/lsb-release-crunchbang)
 					elif [[ -f /etc/siduction-version ]]; then
 						distro="Siduction"
 						distro_release="(Debian Sid)"
@@ -632,10 +647,10 @@ detectdistro () {
 					elif [[ -f /etc/os-release ]]; then
 						if grep -q -i 'Raspbian' /etc/os-release ; then
 							distro="Raspbian"
-							distro_release=$(awk -F'=' '/^PRETTY_NAME=/ {print $2}' /etc/os-release)
+							distro_release=$("${AWK}" -F'=' '/^PRETTY_NAME=/ {print $2}' /etc/os-release)
 						elif grep -q -i 'BlankOn' /etc/os-release ; then
 							distro='BlankOn'
-							distro_release=$(awk -F'=' '/^PRETTY_NAME=/ {print $2}' /etc/os-release)
+							distro_release=$("${AWK}" -F'=' '/^PRETTY_NAME=/ {print $2}' /etc/os-release)
 						else
 							distro="Debian"
 						fi
@@ -655,7 +670,7 @@ detectdistro () {
 					;;
 				"Sulin")
 					distro="Sulin"
-					distro_release=$(awk -F'=' '/^ID_LIKE=/ {print $2}' /etc/os-release)
+					distro_release=$("${AWK}" -F'=' '/^ID_LIKE=/ {print $2}' /etc/os-release)
 					distro_codename="Roolling donkey" # this is not wrong :D
 					;;
 				"KaOS"|"kaos")
@@ -738,7 +753,7 @@ detectdistro () {
 						if grep -q 'SailfishOS' /etc/os-release; then
 							distro="SailfishOS"
 							distro_codename="$(grep 'VERSION=' /etc/os-release | cut -d '(' -f2 | cut -d ')' -f1)"
-							distro_release="$(awk -F'=' '/^VERSION=/ {print $2}' /etc/os-release)"
+							distro_release="$("${AWK}" -F'=' '/^VERSION=/ {print $2}' /etc/os-release)"
 						fi
 					fi
 					;;
@@ -773,7 +788,7 @@ detectdistro () {
 						if grep -q -i 'SUSE Linux Enterprise' /etc/os-release ; then
 							distro="SUSE Linux Enterprise"
 							distro_codename="n/a"
-							distro_release=$(awk -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release | tr -d '"')
+							distro_release=$("${AWK}" -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release | tr -d '"')
 						fi
 					fi
 					if [[ "${distro_codename}" == "Tumbleweed" ]]; then
@@ -809,7 +824,7 @@ detectdistro () {
 					distro="SailfishOS"
 					if [[ -f /etc/os-release ]]; then
 						distro_codename="$(grep 'VERSION=' /etc/os-release | cut -d '(' -f2 | cut -d ')' -f1)"
-						distro_release="$(awk -F'=' '/^VERSION=/ {print $2}' /etc/os-release)"
+						distro_release="$("${AWK}" -F'=' '/^VERSION=/ {print $2}' /etc/os-release)"
 					fi
 					;;
 				"Sparky"|"SparkyLinux")
@@ -889,12 +904,12 @@ detectdistro () {
 					;;
 					"Haiku")
 						distro="Haiku"
-						distro_more="$(uname -v | awk '/^hrev/ {print $1}')"
+						distro_more="$(uname -v | "${AWK}" '/^hrev/ {print $1}')"
 					;;
 					"GNU/Linux")
 						if type -p crux >/dev/null 2>&1; then
 							distro="CRUX"
-							distro_more="$(crux | awk '{print $3}')"
+							distro_more="$(crux | "${AWK}" '{print $3}')"
 						fi
 						if type -p nixos-version >/dev/null 2>&1; then
 							distro="NixOS"
@@ -971,7 +986,7 @@ detectdistro () {
 					[[ "${distro}" == "Neon" ]] && distro="KDE neon"
 					[[ "${distro}" == "SLED" || "${distro}" == "sled" || "${distro}" == "SLES" || "${distro}" == "sles" ]] && distro="SUSE Linux Enterprise"
 					if [[ "${distro}" == "SUSE Linux Enterprise" && -f /etc/os-release ]]; then
-						distro_more="$(awk -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release | tr -d '"')"
+						distro_more="$("${AWK}" -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release | tr -d '"')"
 					fi
 					if [[ "${distro}" == "Debian" && -f /usr/bin/pveversion ]]; then
 						distro="Proxmox VE"
@@ -983,7 +998,7 @@ detectdistro () {
 
 			if [[ "${distro}" == "Unknown" && "${OSTYPE}" =~ "linux" && -f /etc/lsb-release ]]; then
 				LSB_RELEASE=$(</etc/lsb-release)
-				distro=$(echo "${LSB_RELEASE}" | awk 'BEGIN {
+				distro=$(echo "${LSB_RELEASE}" | "${AWK}" 'BEGIN {
 					distro = "Unknown"
 				}
 				{
@@ -1029,7 +1044,7 @@ detectdistro () {
 					if [ -f /etc/os-release ]; then
 						if grep -q -i 'SUSE Linux Enterprise' /etc/os-release ; then
 							distro="SUSE Linux Enterprise"
-							distro_more=$(awk -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release | tr -d '"')
+							distro_more=$("${AWK}" -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release | tr -d '"')
 						fi
 					fi
 					if [[ "${distro_more}" =~ "Tumbleweed" ]]; then
@@ -1081,7 +1096,7 @@ detectdistro () {
 					elif [[ -x /usr/bin/sw_vers ]] && /usr/bin/sw_vers | grep -i 'macOS' >/dev/null; then
 						distro="macOS"
 					elif [[ -f /var/run/dmesg.boot ]]; then
-						distro=$(awk 'BEGIN {
+						distro=$("${AWK}" 'BEGIN {
 							distro = "Unknown"
 						}
 						{
@@ -1110,7 +1125,7 @@ detectdistro () {
 
 			if [[ "${distro}" == "Unknown" ]] && [[ "${OSTYPE}" =~ "linux" || "${OSTYPE}" == "gnu" ]]; then
 				if [[ -f /etc/issue ]]; then
-					distro=$(awk 'BEGIN {
+					distro=$("${AWK}" 'BEGIN {
 						distro = "Unknown"
 					}
 					{
@@ -1153,8 +1168,8 @@ detectdistro () {
 					fi
 				elif [[ -f /etc/lsb-release ]]; then
 					if grep -q -i 'CHROMEOS_RELEASE_NAME' /etc/lsb-release; then
-						distro="$(awk -F'=' '/^CHROMEOS_RELEASE_NAME=/ {print $2}' /etc/lsb-release)"
-						distro_more="$(awk -F'=' '/^CHROMEOS_RELEASE_VERSION=/ {print $2}' /etc/lsb-release)"
+						distro="$("${AWK}" -F'=' '/^CHROMEOS_RELEASE_NAME=/ {print $2}' /etc/lsb-release)"
+						distro_more="$("${AWK}" -F'=' '/^CHROMEOS_RELEASE_VERSION=/ {print $2}' /etc/lsb-release)"
 					fi
 				fi
 			fi
@@ -1339,7 +1354,7 @@ detectuptime () {
 		now=$(date +%s)
 		uptime=$((now - boot))
 	elif [[ "${distro}" == "Haiku" ]]; then
-		uptime=$(uptime | awk -F', up ' '{gsub(/ *hours?,/, "h"); gsub(/ *minutes?/, "m"); print $2;}')
+		uptime=$(uptime | "${AWK}" -F', up ' '{gsub(/ *hours?,/, "h"); gsub(/ *minutes?/, "m"); print $2;}')
 	else
 		if [[ -f /proc/uptime ]]; then
 			uptime=$(</proc/uptime)
@@ -1360,9 +1375,9 @@ detectuptime () {
 		fi
 	else
 		if [[ "$distro" =~ "NetBSD" ]]; then
-			uptime=$(awk -F. '{print $1}' /proc/uptime)
+			uptime=$("${AWK}" -F. '{print $1}' /proc/uptime)
 		elif [[ "$distro" =~ "BSD" ]]; then
-			uptime=$(uptime | awk '{$1=$2=$(NF-6)=$(NF-5)=$(NF-4)=$(NF-3)=$(NF-2)=$(NF-1)=$NF=""; sub(" days","d");sub(",","");sub(":","h ");sub(",","m"); print}')
+			uptime=$(uptime | "${AWK}" '{$1=$2=$(NF-6)=$(NF-5)=$(NF-4)=$(NF-3)=$(NF-2)=$(NF-1)=$NF=""; sub(" days","d");sub(",","");sub(":","h ");sub(",","m"); print}')
 		fi
 	fi
 	verboseOut "Finding current uptime...found as '${uptime}'"
@@ -1526,21 +1541,21 @@ detectcpu () {
 			cpu="Unknown"
 		fi
 	elif [ "$distro" == "FreeBSD" ]; then
-		cpu=$(dmesg | awk -F': ' '/^CPU/ {gsub(/ +/," "); gsub(/\([^\(\)]*\)|CPU /,"", $2); print $2; exit}')
+		cpu=$(dmesg | "${AWK}" -F': ' '/^CPU/ {gsub(/ +/," "); gsub(/\([^\(\)]*\)|CPU /,"", $2); print $2; exit}')
 	elif [ "$distro" == "DragonFlyBSD" ]; then
 		cpu=$(sysctl -n hw.model)
 	elif [ "$distro" == "OpenBSD" ]; then
 		cpu=$(sysctl -n hw.model | sed 's/@.*//')
 	elif [ "$distro" == "Haiku" ]; then
-		cpu=$(sysinfo -cpu | awk -F': ' '/^CPU #0/ {gsub(/ +/," "); gsub(/\([^\(\)]*\)|CPU /,"", $2); print $2; exit}')
+		cpu=$(sysinfo -cpu | "${AWK}" -F': ' '/^CPU #0/ {gsub(/ +/," "); gsub(/\([^\(\)]*\)|CPU /,"", $2); print $2; exit}')
 	else
-		cpu=$(awk -F':' '/^model name/ {split($2, A, " @"); print A[1]; exit}' /proc/cpuinfo)
+		cpu=$("${AWK}" -F':' '/^model name/ {split($2, A, " @"); print A[1]; exit}' /proc/cpuinfo)
 		cpun=$(grep -c '^processor' /proc/cpuinfo)
 		if [ -z "$cpu" ]; then
-			cpu=$(awk 'BEGIN{FS=":"} /Hardware/ { print $2; exit }' /proc/cpuinfo)
+			cpu=$("${AWK}" 'BEGIN{FS=":"} /Hardware/ { print $2; exit }' /proc/cpuinfo)
 		fi
 		if [ -z "$cpu" ]; then
-			cpu=$(awk 'BEGIN{FS=":"} /^cpu/ { gsub(/  +/," ",$2); print $2; exit}' /proc/cpuinfo | sed 's/, altivec supported//;s/^ //')
+			cpu=$("${AWK}" 'BEGIN{FS=":"} /^cpu/ { gsub(/  +/," ",$2); print $2; exit}' /proc/cpuinfo | sed 's/, altivec supported//;s/^ //')
 			if [[ $cpu =~ ^(PPC)*9.+ ]]; then
 				model="IBM PowerPC G5 "
 			elif [[ $cpu =~ 740/750 ]]; then
@@ -1588,15 +1603,15 @@ detectcpu () {
 		bl="${loc}/bios_limit"
 		smf="${loc}/scaling_max_freq"
 		if [ -f "$bl" ] && [ -r "$bl" ]; then
-			cpu_mhz=$(awk '{print $1/1000}' "$bl")
+			cpu_mhz=$("${AWK}" '{print $1/1000}' "$bl")
 		elif [ -f "$smf" ] && [ -r "$smf" ]; then
-			cpu_mhz=$(awk '{print $1/1000}' "$smf")
+			cpu_mhz=$("${AWK}" '{print $1/1000}' "$smf")
 		else
-			cpu_mhz=$(awk -F':' '/cpu MHz/{ print int($2+.5) }' /proc/cpuinfo | head -n 1)
+			cpu_mhz=$("${AWK}" -F':' '/cpu MHz/{ print int($2+.5) }' /proc/cpuinfo | head -n 1)
 		fi
 		if [ -n "$cpu_mhz" ]; then
 			if [ "${cpu_mhz%.*}" -ge 1000 ]; then
-				cpu_ghz=$(awk '{print $1/1000}' <<< "${cpu_mhz}")
+				cpu_ghz=$("${AWK}" '{print $1/1000}' <<< "${cpu_mhz}")
 				cpufreq="${cpu_ghz}GHz"
 			else
 				cpufreq="${cpu_mhz}MHz"
@@ -1650,16 +1665,16 @@ detectgpu () {
 			# gpu=$(sed 's/.*device.*= //' <<< "${gpu_info}" | sed "s/'//g")
 		fi
 	elif [[ "${distro}" == "OpenBSD" ]]; then
-		gpu=$(glxinfo 2> /dev/null | awk '/OpenGL renderer string/ { sub(/OpenGL renderer string: /,""); print }')
+		gpu=$(glxinfo 2> /dev/null | "${AWK}" '/OpenGL renderer string/ { sub(/OpenGL renderer string: /,""); print }')
 	elif [[ "${distro}" == "Mac OS X" || "${distro}" == "macOS" ]]; then
-		gpu=$(system_profiler SPDisplaysDataType | awk -F': ' '/^ *Chipset Model:/ {print $2}' | awk '{ printf "%s / ", $0 }' | sed -e 's/\/ $//g')
+		gpu=$(system_profiler SPDisplaysDataType | "${AWK}" -F': ' '/^ *Chipset Model:/ {print $2}' | "${AWK}" '{ printf "%s / ", $0 }' | sed -e 's/\/ $//g')
 	elif [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" ]]; then
 		gpu=$(wmic path Win32_VideoController get caption | sed -n '2p')
 	elif [[ "${distro}" == "Haiku" ]]; then
-		gpu="$(listdev | grep -A2 -e 'device Display controller' | awk -F': ' '/^ +device/ {print $2}')"
+		gpu="$(listdev | grep -A2 -e 'device Display controller' | "${AWK}" -F': ' '/^ +device/ {print $2}')"
 	else
 		if [[ -n "$(PATH="/opt/bin:$PATH" type -p nvidia-smi)" ]]; then
-			gpu=$($(PATH="/opt/bin:$PATH" type -p nvidia-smi | cut -f1) -q | awk -F':' '/Product Name/ {gsub(/: /,":"); print $2}' | sed ':a;N;$!ba;s/\n/, /g')
+			gpu=$($(PATH="/opt/bin:$PATH" type -p nvidia-smi | cut -f1) -q | "${AWK}" -F':' '/Product Name/ {gsub(/: /,":"); print $2}' | sed ':a;N;$!ba;s/\n/, /g')
 		elif [[ -n "$(PATH="/usr/sbin:$PATH" type -p glxinfo)" && -z "${gpu}" ]]; then
 			gpu_info=$($(PATH="/usr/sbin:$PATH" type -p glxinfo | cut -f1) 2>/dev/null)
 			gpu=$(grep "OpenGL renderer string" <<< "${gpu_info}" | cut -d ':' -f2 | sed -n -e '1h;2,$H;${g;s/\n/, /g' -e 'p' -e '}')
@@ -1697,12 +1712,12 @@ detectgpu () {
 # Run it only on Intel Processors if GPU is unknown
 DetectIntelGPU() {
 	if [ -r /proc/fb ]; then
-		gpu=$(awk 'BEGIN {ORS = " &"} {$1="";print}' /proc/fb | sed  -r s/'^\s+|\s*&$'//g)
+		gpu=$("${AWK}" 'BEGIN {ORS = " &"} {$1="";print}' /proc/fb | sed  -r s/'^\s+|\s*&$'//g)
 	fi
 
 	case $gpu in
 		*mfb)
-			gpu=$(lspci | grep -i vga | awk -F ": " '{print $2}')
+			gpu=$(lspci | grep -i vga | "${AWK}" -F ": " '{print $2}')
 			;;
 		*intel*)
 			gpu="intel"
@@ -1714,7 +1729,7 @@ DetectIntelGPU() {
 
 	if [[ "$gpu" = "intel" ]]; then
 		#Detect CPU
-		local CPU=$(uname -p | awk '{print $3}')
+		local CPU=$(uname -p | "${AWK}" '{print $3}')
 		CPU=${CPU#*'-'}; #Detect CPU number
 
 		#Detect Intel GPU
@@ -1757,12 +1772,12 @@ detectdisk () {
 		if [[ "${distro}" =~ (Free|Net|DragonFly)BSD ]]; then
 			totaldisk=$(df -h -c 2>/dev/null | tail -1)
 		elif [[ "${distro}" == "OpenBSD" ]]; then
-			totaldisk=$(df -Pk 2> /dev/null | awk '
+			totaldisk=$(df -Pk 2> /dev/null | "${AWK}" '
 				/^\// {total+=$2; used+=$3; avail+=$4}
 				END{printf("total %.1fG %.1fG %.1fG %d%%\n", total/1048576, used/1048576, avail/1048576, used*100/total)}')
 		elif [[ "${distro}" == "Mac OS X" || "${distro}" == "macOS" ]]; then
-                        majorVers=$(sw_vers --productVersion | cut -d ':' -f 2 | awk -F "." '{print $1}') # Major version
-			minorVers=$(sw_vers --productVersion | cut -d ':' -f 2 | awk -F "." '{print $2}') # Minor version
+                        majorVers=$(sw_vers --productVersion | cut -d ':' -f 2 | "${AWK}" -F "." '{print $1}') # Major version
+			minorVers=$(sw_vers --productVersion | cut -d ':' -f 2 | "${AWK}" -F "." '{print $2}') # Minor version
 			if [[ "${minorVers}" -ge "15" || "${majorVers}" -ge "11" ]]; then # Catalina or newer
 				totaldisk=$(df -H /System/Volumes/Data 2>/dev/null | tail -1)
 			else
@@ -1771,9 +1786,9 @@ detectdisk () {
 		else
 			totaldisk=$(df -h -x aufs -x tmpfs -x overlay -x drvfs -x devtmpfs --total 2>/dev/null | tail -1)
 		fi
-		disktotal=$(awk '{print $2}' <<< "${totaldisk}")
-		diskused=$(awk '{print $3}' <<< "${totaldisk}")
-		diskusedper=$(awk '{print $5}' <<< "${totaldisk}")
+		disktotal=$("${AWK}" '{print $2}' <<< "${totaldisk}")
+		diskused=$("${AWK}" '{print $3}' <<< "${totaldisk}")
+		diskusedper=$("${AWK}" '{print $5}' <<< "${totaldisk}")
 		diskusage="${diskused} / ${disktotal} (${diskusedper})"
 		diskusage_verbose=$(sed 's/%/%%/' <<< "$diskusage")
 	fi
@@ -1786,17 +1801,17 @@ detectdisk () {
 detectmem () {
 	if [[ "$distro" == "Mac OS X" || "$distro" == "macOS" ]]; then
 		totalmem=$(echo "$(sysctl -n hw.memsize)" / 1024^2 | bc)
-		wiredmem=$(vm_stat | grep wired | awk '{ print $4 }' | sed 's/\.//')
-		activemem=$(vm_stat | grep ' active' | awk '{ print $3 }' | sed 's/\.//')
-		compressedmem=$(vm_stat | grep occupied | awk '{ print $5 }' | sed 's/\.//')
+		wiredmem=$(vm_stat | grep wired | "${AWK}" '{ print $4 }' | sed 's/\.//')
+		activemem=$(vm_stat | grep ' active' | "${AWK}" '{ print $3 }' | sed 's/\.//')
+		compressedmem=$(vm_stat | grep occupied | "${AWK}" '{ print $5 }' | sed 's/\.//')
 		if [[ ! -z "$compressedmem | tr -d" ]]; then  # FIXME: is this line correct?
 			compressedmem=0
 		fi
 		usedmem=$(((wiredmem + activemem + compressedmem) * 4 / 1024))
 	elif [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" ]]; then
-		total_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)
+		total_mem=$("${AWK}" '/MemTotal/ { print $2 }' /proc/meminfo)
 		totalmem=$((total_mem / 1024))
-		free_mem=$(awk '/MemFree/ { print $2 }' /proc/meminfo)
+		free_mem=$("${AWK}" '/MemFree/ { print $2 }' /proc/meminfo)
 		used_mem=$((total_mem - free_mem))
 		usedmem=$((used_mem / 1024))
 	elif [[ "$distro" == "FreeBSD"  || "$distro" == "DragonFlyBSD" ]]; then
@@ -1822,21 +1837,21 @@ detectmem () {
 		usedmem=$((used_mem / 1024 / 1024))
 	elif [ "$distro" == "OpenBSD" ]; then
 		totalmem=$(($(sysctl -n hw.physmem) / 1024 / 1024))
-		usedmem=$(vmstat | awk '!/[a-z]/{gsub("M",""); print $3}')
+		usedmem=$(vmstat | "${AWK}" '!/[a-z]/{gsub("M",""); print $3}')
 	elif [ "$distro" == "NetBSD" ]; then
-		phys_mem=$(awk '/MemTotal/ { print $2 }' /proc/meminfo)
+		phys_mem=$("${AWK}" '/MemTotal/ { print $2 }' /proc/meminfo)
 		totalmem=$((phys_mem / 1024))
 		if grep -q 'Cached' /proc/meminfo; then
-			cache=$(awk '/Cached/ {print $2}' /proc/meminfo)
+			cache=$("${AWK}" '/Cached/ {print $2}' /proc/meminfo)
 			usedmem=$((cache / 1024))
 		else
-			free_mem=$(awk '/MemFree/ { print $2 }' /proc/meminfo)
+			free_mem=$("${AWK}" '/MemFree/ { print $2 }' /proc/meminfo)
 			used_mem=$((phys_mem - free_mem))
 			usedmem=$((used_mem / 1024))
 		fi
 	elif [ "$distro" == "Haiku" ]; then
-		totalmem=$(sysinfo -mem | awk 'NR == 1 {gsub(/[\(\)\/]/, ""); printf("%d", $6/1024**2)}')
-		usedmem=$(sysinfo -mem | awk 'NR == 1 {gsub(/[\(\)\/]/, ""); printf("%d", $5/1024**2)}')
+		totalmem=$(sysinfo -mem | "${AWK}" 'NR == 1 {gsub(/[\(\)\/]/, ""); printf("%d", $6/1024**2)}')
+		usedmem=$(sysinfo -mem | "${AWK}" 'NR == 1 {gsub(/[\(\)\/]/, ""); printf("%d", $5/1024**2)}')
 	else
 		# MemUsed = Memtotal + Shmem - MemFree - Buffers - Cached - SReclaimable
 		# Source: https://github.com/dylanaraps/neofetch/pull/391/files#diff-e863270127ca6116fd30e708cdc582fc
@@ -1851,7 +1866,7 @@ detectmem () {
 		#done
 		#usedmem=$((usedmem / 1024))
 		#totalmem=$((totalmem / 1024))
-		mem=$(free -b | awk -F ':' 'NR==2{print $2}' | awk '{print $1"-"$6}')
+		mem=$(free -b | "${AWK}" -F ':' 'NR==2{print $2}' | "${AWK}" '{print $1"-"$6}')
 		usedmem=$((mem / 1024 / 1024))
 		totalmem=$((${mem//-*} / 1024 / 1024))
 	fi
@@ -1876,7 +1891,7 @@ detectshell_ver () {
 	esac
 
 	if [[ -n $version_data ]];then
-		version=$(awk '
+		version=$("${AWK}" '
 		BEGIN {
 			IGNORECASE=1
 		}
@@ -1895,16 +1910,16 @@ detectshell () {
 	if [[ ! "${shell_type}" ]]; then
 		if [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" || "${distro}" == "Haiku" || "${distro}" == "Alpine Linux" ||
 			"${distro}" == "Mac OS X" || "${distro}" == "macOS" || "${distro}" == "TinyCore" || "${distro}" == "Raspbian" || "${OSTYPE}" == "gnu" ]]; then
-			shell_type=$(echo "$SHELL" | awk -F'/' '{print $NF}')
+			shell_type=$(echo "$SHELL" | "${AWK}" -F'/' '{print $NF}')
 		elif readlink -f "$SHELL" 2>&1 | grep -q -i 'busybox'; then
 			shell_type="BusyBox"
 		else
 			if [[ "${OSTYPE}" =~ "linux" ]]; then
-				shell_type=$(realpath /proc/$PPID/exe | awk -F'/' '{print $NF}')
+				shell_type=$(realpath /proc/$PPID/exe | "${AWK}" -F'/' '{print $NF}')
 			elif [[ "${distro}" =~ "BSD" ]]; then
 				shell_type=$(ps -p $PPID -o command | tail -1)
 			else
-				shell_type=$(ps -p "$(ps -p $PPID | awk '$1 !~ /PID/ {print $1}')" | awk 'FNR>1 {print $1}')
+				shell_type=$(ps -p "$(ps -p $PPID | "${AWK}" '$1 !~ /PID/ {print $1}')" | "${AWK}" 'FNR>1 {print $1}')
 			fi
 			shell_type=${shell_type/-}
 			shell_type=${shell_type//*\/}
@@ -1934,7 +1949,7 @@ detectshell () {
 			shell_version_data=$( detectshell_ver "$shell_type" "^zsh" "2" )
 			;;
 		fish)
-			shell_version_data=$( fish --version | awk '{print $3}' )
+			shell_version_data=$( fish --version | "${AWK}" '{print $3}' )
 			;;
 		pwsh)
 			shell_version_data=$( pwsh -c '$PSVersionTable.PSVersion.ToString()' )
@@ -1955,17 +1970,17 @@ detectshell () {
 detectres () {
 	xResolution="No X Server"
 	if [[ ${distro} == "Mac OS X" || $distro == "macOS" ]]; then
-		xResolution=$(system_profiler SPDisplaysDataType | awk '/Resolution:/ {print $2"x"$4" "}')
+		xResolution=$(system_profiler SPDisplaysDataType | "${AWK}" '/Resolution:/ {print $2"x"$4" "}')
 		if [[ "$(echo "$xResolution" | wc -l)" -ge 1 ]]; then
 			xResolution=$(echo "$xResolution" | tr " \\n" ", " | sed 's/\(.*\),/\1/')
 		fi
 	elif [[ "${distro}" == "Cygwin" || "${distro}" == "Msys" ]]; then
-		xResolution=$(wmic path Win32_VideoController get CurrentHorizontalResolution,CurrentVerticalResolution | awk 'NR==2 {print $1"x"$2}')
+		xResolution=$(wmic path Win32_VideoController get CurrentHorizontalResolution,CurrentVerticalResolution | "${AWK}" 'NR==2 {print $1"x"$2}')
 	elif [[ "${distro}" == "Haiku" ]]; then
-		xResolution="$(screenmode | grep Resolution | awk '{gsub(/,/,""); print $2"x"$3}')"
+		xResolution="$(screenmode | grep Resolution | "${AWK}" '{gsub(/,/,""); print $2"x"$3}')"
 	elif [[ -n ${DISPLAY} ]]; then
 		if type -p xdpyinfo >/dev/null 2>&1; then
-			xResolution=$(xdpyinfo | awk '/^ +dimensions/ {print $2}')
+			xResolution=$(xdpyinfo | "${AWK}" '/^ +dimensions/ {print $2}')
 		fi
 	fi
 	verboseOut "Finding current resolution(s)...found as '$xResolution'"
@@ -1993,7 +2008,7 @@ detectde () {
 		if type -p xprop >/dev/null 2>&1;then
 			xprop_root="$(xprop -root 2>/dev/null)"
 			if [[ -n ${xprop_root} ]]; then
-				DE=$(echo "${xprop_root}" | awk 'BEGIN {
+				DE=$(echo "${xprop_root}" | "${AWK}" 'BEGIN {
 					de = "Not Present"
 				}
 				{
@@ -2165,7 +2180,7 @@ detectde () {
 				elif [[ ${KDE_FULL_SESSION} == 'true' ]]; then
 					DE="KDE"
 					DEver_data=$(kded --version 2>/dev/null)
-					DEver=$(grep -si '^KDE:' <<< "$DEver_data" | awk '{print $2}')
+					DEver=$(grep -si '^KDE:' <<< "$DEver_data" | "${AWK}" '{print $2}')
 				fi
 			fi
 		fi
@@ -2220,7 +2235,7 @@ detectde () {
 				fi
 			elif [[ ${DE} == "LXQt" ]]; then
 				if type -p lxqt-about >/dev/null 2>&1; then
-					DEver=$(lxqt-about --version | awk '/^liblxqt/ {print $2}')
+					DEver=$(lxqt-about --version | "${AWK}" '/^liblxqt/ {print $2}')
 					DE="${DE} ${DEver}"
 				fi
 			elif [[ ${DE} == "MATE" ]]; then
@@ -2235,12 +2250,12 @@ detectde () {
 				fi
 			elif [[ ${DE} == "Deepin" ]]; then
 				if [[ -f /etc/deepin-version ]]; then
-					DEver="$(awk -F '=' '/Version/ {print $2}' /etc/deepin-version)"
+					DEver="$("${AWK}" -F '=' '/Version/ {print $2}' /etc/deepin-version)"
 					DE="${DE} ${DEver//* }"
 				fi
 			elif [[ ${DE} == "Trinity" ]]; then
 				if type -p tde-config >/dev/null 2>&1; then
-					DEver="$(tde-config --version | awk -F ' ' '/TDE:/ {print $2}')"
+					DEver="$(tde-config --version | "${AWK}" -F ' ' '/TDE:/ {print $2}')"
 					DE="${DE} ${DEver//* }"
 				fi
 			fi
@@ -2484,7 +2499,7 @@ detectwmtheme () {
 			else
 				themeFile="$(reg query 'HKCU\Software\Microsoft\Windows\CurrentVersion\Themes' /v 'CurrentTheme')"
 			fi
-			Win_theme=$(echo "$themeFile" | awk -F"\\" '{print $NF}' | sed 's|\.theme$||')
+			Win_theme=$(echo "$themeFile" | "${AWK}" -F"\\" '{print $NF}' | sed 's|\.theme$||')
 		fi
 	else
 		case $WM in
@@ -2499,7 +2514,7 @@ detectwmtheme () {
 			;;
 			'BlackBox')
 				if [ -f "$HOME/.blackboxrc" ]; then
-					Win_theme="$(awk -F"/" '/styleFile/ {print $NF}' "$HOME/.blackboxrc")"
+					Win_theme="$("${AWK}" -F"/" '/styleFile/ {print $NF}' "$HOME/.blackboxrc")"
 				fi
 			;;
 			'BudgieWM')
@@ -2531,11 +2546,11 @@ detectwmtheme () {
 				fi
 			;;
 			'E16')
-				Win_theme="$(awk -F"= " '/theme.name/ {print $2}' $HOME/.e16/e_config--*.cfg)"
+				Win_theme="$("${AWK}" -F"= " '/theme.name/ {print $2}' $HOME/.e16/e_config--*.cfg)"
 			;;
 			'E17'|'Enlightenment')
 				if [ "$(which eet 2>/dev/null)" ]; then
-					econfig="$(eet -d "$HOME/.e/e/config/standard/e.cfg" config | awk '/value \"file\" string.*.edj/{ print $4 }')"
+					econfig="$(eet -d "$HOME/.e/e/config/standard/e.cfg" config | "${AWK}" '/value \"file\" string.*.edj/{ print $4 }')"
 					econfigend="${econfig##*/}"
 					Win_theme=${econfigend%.*}
 				elif [ -n "${E_CONF_PROFILE}" ]; then
@@ -2551,12 +2566,12 @@ detectwmtheme () {
 			;;
 			'FluxBox'|'Fluxbox')
 				if [ -f "$HOME/.fluxbox/init" ]; then
-					Win_theme="$(awk -F"/" '/styleFile/ {print $NF}' "$HOME/.fluxbox/init")"
+					Win_theme="$("${AWK}" -F"/" '/styleFile/ {print $NF}' "$HOME/.fluxbox/init")"
 				fi
 			;;
 			'IceWM')
 				if [ -f "$HOME/.icewm/theme" ]; then
-					Win_theme="$(awk -F"[\",/]" '!/#/ {print $2}' "$HOME/.icewm/theme")"
+					Win_theme="$("${AWK}" -F"[\",/]" '!/#/ {print $2}' "$HOME/.icewm/theme")"
 				fi
 			;;
 			'KWin'*)
@@ -2573,14 +2588,14 @@ detectwmtheme () {
 					Win_theme="Not Applicable"
 					KDE_CONFIG_DIR=${KDE_CONFIG_DIR%/}
 					if [[ -f $KDE_CONFIG_DIR/share/config/kwinrc ]]; then
-						Win_theme="$(awk '/PluginLib=kwin3_/{gsub(/PluginLib=kwin3_/,"",$0); print $0; exit}' "$KDE_CONFIG_DIR/share/config/kwinrc")"
+						Win_theme="$("${AWK}" '/PluginLib=kwin3_/{gsub(/PluginLib=kwin3_/,"",$0); print $0; exit}' "$KDE_CONFIG_DIR/share/config/kwinrc")"
 						if [[ -z "$Win_theme" ]]; then
 							Win_theme="Not Applicable"
 						fi
 					fi
 					if [[ "$Win_theme" == "Not Applicable" ]]; then
 						if [[ -f $KDE_CONFIG_DIR/share/config/kdebugrc ]]; then
-							Win_theme="$(awk '/(decoration)/ {gsub(/\[/,"",$1); print $1; exit}' "$KDE_CONFIG_DIR/share/config/kdebugrc")"
+							Win_theme="$("${AWK}" '/(decoration)/ {gsub(/\[/,"",$1); print $1; exit}' "$KDE_CONFIG_DIR/share/config/kdebugrc")"
 							if [[ -z "$Win_theme" ]]; then
 								Win_theme="Not Applicable"
 							fi
@@ -2588,7 +2603,7 @@ detectwmtheme () {
 					fi
 					if [[ "$Win_theme" == "Not Applicable" ]]; then
 						if [[ -f $KDE_CONFIG_DIR/share/config/kdeglobals ]]; then
-							Win_theme="$(awk '/\[General\]/ {flag=1;next} /^$/{flag=0} flag {print}' "$KDE_CONFIG_DIR/share/config/kdeglobals" | grep -oP 'Name=\K.*')"
+							Win_theme="$("${AWK}" '/\[General\]/ {flag=1;next} /^$/{flag=0} flag {print}' "$KDE_CONFIG_DIR/share/config/kdeglobals" | grep -oP 'Name=\K.*')"
 							if [[ -z "$Win_theme" ]]; then
 								Win_theme="Not Applicable"
 							fi
@@ -2618,20 +2633,20 @@ detectwmtheme () {
 			;;
 			'OpenBox'|'Openbox')
 				if [ -f "${XDG_CONFIG_HOME:-${HOME}/.config}/openbox/rc.xml" ]; then
-					Win_theme="$(awk -F"[<,>]" '/<theme/ { getline; print $3 }' "${XDG_CONFIG_HOME:-${HOME}/.config}/openbox/rc.xml")";
+					Win_theme="$("${AWK}" -F"[<,>]" '/<theme/ { getline; print $3 }' "${XDG_CONFIG_HOME:-${HOME}/.config}/openbox/rc.xml")";
 				elif [[ -f ${XDG_CONFIG_HOME:-${HOME}/.config}/openbox/lxde-rc.xml && "${DE}" == "LXDE" ]]; then
-					Win_theme="$(awk -F"[<,>]" '/<theme/ { getline; print $3 }' "${XDG_CONFIG_HOME:-${HOME}/.config}/openbox/lxde-rc.xml")";
+					Win_theme="$("${AWK}" -F"[<,>]" '/<theme/ { getline; print $3 }' "${XDG_CONFIG_HOME:-${HOME}/.config}/openbox/lxde-rc.xml")";
 				elif [[ -f ${XDG_CONFIG_HOME:-${HOME}/.config}/openbox/lxqt-rc.xml && "${DE}" =~ "LXQt" ]]; then
-					Win_theme="$(awk -F'=' '/^theme/ {print $2}' ${HOME}/.config/lxqt/lxqt.conf)"
+					Win_theme="$("${AWK}" -F'=' '/^theme/ {print $2}' ${HOME}/.config/lxqt/lxqt.conf)"
 				fi
 			;;
 			'PekWM')
 				if [ -f "$HOME/.pekwm/config" ]; then
-					Win_theme="$(awk -F"/" '/Theme/ {gsub(/\"/,""); print $NF}' "$HOME/.pekwm/config")"
+					Win_theme="$("${AWK}" -F"/" '/Theme/ {gsub(/\"/,""); print $NF}' "$HOME/.pekwm/config")"
 				fi
 			;;
 			'Sawfish')
-				Win_theme="$(awk -F")" '/\(quote default-frame-style/{print $2}' "$HOME/.sawfish/custom" | sed 's/ (quote //')"
+				Win_theme="$("${AWK}" -F")" '/\(quote default-frame-style/{print $2}' "$HOME/.sawfish/custom" | sed 's/ (quote //')"
 			;;
 			'TWin')
 				if [[ -z $TDE_CONFIG_DIR ]]; then
@@ -2642,7 +2657,7 @@ detectwmtheme () {
 				if [[ -n $TDE_CONFIG_DIR ]]; then
 					TDE_CONFIG_DIR=${TDE_CONFIG_DIR%/}
 					if [[ -f $TDE_CONFIG_DIR/share/config/kcmthememanagerrc ]]; then
-						Win_theme=$(awk '/CurrentTheme=/ {gsub(/CurrentTheme=/,"",$0); print $0; exit}' "$TDE_CONFIG_DIR/share/config/kcmthememanagerrc")
+						Win_theme=$("${AWK}" '/CurrentTheme=/ {gsub(/CurrentTheme=/,"",$0); print $0; exit}' "$TDE_CONFIG_DIR/share/config/kcmthememanagerrc")
 					fi
 					if [[ -z $Win_theme ]]; then
 						Win_theme="Not Applicable"
@@ -2734,31 +2749,31 @@ detectgtk () {
 
 				if [[ -n ${KDE_CONFIG_FILE} ]]; then
 					if grep -q 'widgetStyle=' "${KDE_CONFIG_FILE}"; then
-						gtk2Theme=$(awk -F"=" '/widgetStyle=/ {print $2}' "${KDE_CONFIG_FILE}")
+						gtk2Theme=$("${AWK}" -F"=" '/widgetStyle=/ {print $2}' "${KDE_CONFIG_FILE}")
 					elif grep -q 'colorScheme=' "${KDE_CONFIG_FILE}"; then
-						gtk2Theme=$(awk -F"=" '/colorScheme=/ {print $2}' "${KDE_CONFIG_FILE}")
+						gtk2Theme=$("${AWK}" -F"=" '/colorScheme=/ {print $2}' "${KDE_CONFIG_FILE}")
 					fi
 
 					if grep -q 'Theme=' "${KDE_CONFIG_FILE}"; then
-						gtkIcons=$(awk -F"=" '/Theme=/ {print $2}' "${KDE_CONFIG_FILE}")
+						gtkIcons=$("${AWK}" -F"=" '/Theme=/ {print $2}' "${KDE_CONFIG_FILE}")
 					fi
 
 					if grep -q 'Font=' "${KDE_CONFIG_FILE}"; then
-						gtkFont=$(awk -F"=" '/font=/ {print $2}' "${KDE_CONFIG_FILE}")
+						gtkFont=$("${AWK}" -F"=" '/font=/ {print $2}' "${KDE_CONFIG_FILE}")
 					fi
 				fi
 
 				if [[ -f $HOME/.gtkrc-2.0 ]]; then
-					gtk2Theme=$(grep '^gtk-theme-name' "$HOME"/.gtkrc-2.0 | awk -F'=' '{print $2}')
+					gtk2Theme=$(grep '^gtk-theme-name' "$HOME"/.gtkrc-2.0 | "${AWK}" -F'=' '{print $2}')
 					gtk2Theme=${gtk2Theme//\"/}
-					gtkIcons=$(grep '^gtk-icon-theme-name' "$HOME"/.gtkrc-2.0 | awk -F'=' '{print $2}')
+					gtkIcons=$(grep '^gtk-icon-theme-name' "$HOME"/.gtkrc-2.0 | "${AWK}" -F'=' '{print $2}')
 					gtkIcons=${gtkIcons//\"/}
-					gtkFont=$(grep 'font_name' "$HOME"/.gtkrc-2.0 | awk -F'=' '{print $2}')
+					gtkFont=$(grep 'font_name' "$HOME"/.gtkrc-2.0 | "${AWK}" -F'=' '{print $2}')
 					gtkFont=${gtkFont//\"/}
 				fi
 
 				if [[ -f $HOME/.config/gtk-3.0/settings.ini ]]; then
-					gtk3Theme=$(grep '^gtk-theme-name=' "$HOME"/.config/gtk-3.0/settings.ini | awk -F'=' '{print $2}')
+					gtk3Theme=$(grep '^gtk-theme-name=' "$HOME"/.config/gtk-3.0/settings.ini | "${AWK}" -F'=' '{print $2}')
 				fi
 			;;
 			'Cinnamon'*) # Desktop Environment found as "Cinnamon"
@@ -2790,7 +2805,7 @@ detectgtk () {
 					gtkFont=$(gconftool-2 -g /desktop/gnome/interface/font_name)
 					if [ "$background_detect" == "1" ]; then
 						gtkBackgroundFull=$(gconftool-2 -g /desktop/gnome/background/picture_filename)
-						gtkBackground=$(echo "$gtkBackgroundFull" | awk -F"/" '{print $NF}')
+						gtkBackground=$(echo "$gtkBackgroundFull" | "${AWK}" -F"/" '{print $NF}')
 					fi
 				fi
 			;;
@@ -2807,10 +2822,10 @@ detectgtk () {
 			;;
 			'Xfce'*) # Desktop Environment found as "Xfce"
 				if [ "$distro" == "BunsenLabs" ] ; then
-					gtk2Theme=$(awk -F'"' '/^gtk-theme/ {print $2}' "$HOME"/.gtkrc-2.0)
-					gtk3Theme=$(awk -F'=' '/^gtk-theme-name/ {print $2}' "$HOME"/.config/gtk-3.0/settings.ini)
-					gtkIcons=$(awk -F'"' '/^gtk-icon-theme/ {print $2}' "$HOME"/.gtkrc-2.0)
-					gtkFont=$(awk -F'"' '/^gtk-font-name/ {print $2}' "$HOME"/.gtkrc-2.0)
+					gtk2Theme=$("${AWK}" -F'"' '/^gtk-theme/ {print $2}' "$HOME"/.gtkrc-2.0)
+					gtk3Theme=$("${AWK}" -F'=' '/^gtk-theme-name/ {print $2}' "$HOME"/.config/gtk-3.0/settings.ini)
+					gtkIcons=$("${AWK}" -F'"' '/^gtk-icon-theme/ {print $2}' "$HOME"/.gtkrc-2.0)
+					gtkFont=$("${AWK}" -F'"' '/^gtk-font-name/ {print $2}' "$HOME"/.gtkrc-2.0)
 				else
 					if type -p xfconf-query >/dev/null 2>&1; then
 						gtk2Theme=$(xfconf-query -c xsettings -p /Net/ThemeName 2>/dev/null)
@@ -2841,15 +2856,15 @@ detectgtk () {
 				fi
 
 				if grep -q 'sNet\/ThemeName' "${config_home}${lxdeconf}" 2>/dev/null; then
-					gtk2Theme=$(awk -F'=' '/sNet\/ThemeName/ {print $2}' "${config_home}${lxdeconf}")
+					gtk2Theme=$("${AWK}" -F'=' '/sNet\/ThemeName/ {print $2}' "${config_home}${lxdeconf}")
 				fi
 
 				if grep -q 'IconThemeName' "${config_home}${lxdeconf}" 2>/dev/null; then
-					gtkIcons=$(awk -F'=' '/sNet\/IconThemeName/ {print $2}' "${config_home}${lxdeconf}")
+					gtkIcons=$("${AWK}" -F'=' '/sNet\/IconThemeName/ {print $2}' "${config_home}${lxdeconf}")
 				fi
 
 				if grep -q 'FontName' "${config_home}${lxdeconf}" 2>/dev/null; then
-					gtkFont=$(awk -F'=' '/sGtk\/FontName/ {print $2}' "${config_home}${lxdeconf}")
+					gtkFont=$("${AWK}" -F'=' '/sGtk\/FontName/ {print $2}' "${config_home}${lxdeconf}")
  				fi
 			;;
 
@@ -2858,15 +2873,15 @@ detectgtk () {
 			*)	# Lightweight or No DE Found
 				if [ -f "$HOME/.gtkrc-2.0" ]; then
 					if grep -q 'gtk-theme' "$HOME/.gtkrc-2.0"; then
-						gtk2Theme=$(awk -F'"' '/^gtk-theme/ {print $2}' "$HOME/.gtkrc-2.0")
+						gtk2Theme=$("${AWK}" -F'"' '/^gtk-theme/ {print $2}' "$HOME/.gtkrc-2.0")
 					fi
 
 					if grep -q 'icon-theme' "$HOME/.gtkrc-2.0"; then
-						gtkIcons=$(awk -F'"' '/^gtk-icon-theme/ {print $2}' "$HOME/.gtkrc-2.0")
+						gtkIcons=$("${AWK}" -F'"' '/^gtk-icon-theme/ {print $2}' "$HOME/.gtkrc-2.0")
 					fi
 
 					if grep -q 'font' "$HOME/.gtkrc-2.0"; then
-						gtkFont=$(awk -F'"' '/^gtk-font-name/ {print $2}' "$HOME/.gtkrc-2.0")
+						gtkFont=$("${AWK}" -F'"' '/^gtk-font-name/ {print $2}' "$HOME/.gtkrc-2.0")
 					fi
 				fi
 				# $HOME/.gtkrc.mine theme detect only
@@ -2877,37 +2892,37 @@ detectgtk () {
 				fi
 				if [ -f "$minegtkrc" ]; then
 					if grep -q '^include' "$minegtkrc"; then
-						gtk2Theme=$(grep '^include.*gtkrc' "$minegtkrc" | awk -F "/" '{ print $5 }')
+						gtk2Theme=$(grep '^include.*gtkrc' "$minegtkrc" | "${AWK}" -F "/" '{ print $5 }')
 					fi
 					if grep -q '^gtk-icon-theme-name' "$minegtkrc"; then
-						gtkIcons=$(grep '^gtk-icon-theme-name' "$minegtkrc" | awk -F '"' '{print $2}')
+						gtkIcons=$(grep '^gtk-icon-theme-name' "$minegtkrc" | "${AWK}" -F '"' '{print $2}')
 					fi
 				fi
 				# /etc/gtk-2.0/gtkrc compatibility
 				if [[ -f /etc/gtk-2.0/gtkrc && ! -f "$HOME/.gtkrc-2.0" && ! -f "$HOME/.gtkrc.mine" && ! -f "$HOME/.gtkrc-2.0.mine" ]]; then
 					if grep -q 'gtk-theme-name' /etc/gtk-2.0/gtkrc; then
-						gtk2Theme=$(awk -F'"' '/^gtk-theme-name/ {print $2}' /etc/gtk-2.0/gtkrc)
+						gtk2Theme=$("${AWK}" -F'"' '/^gtk-theme-name/ {print $2}' /etc/gtk-2.0/gtkrc)
 					fi
 					if grep -q 'gtk-fallback-theme-name' /etc/gtk-2.0/gtkrc  && ! [ "x$gtk2Theme" = "x" ]; then
-						gtk2Theme=$(awk -F'"' '/^gtk-fallback-theme-name/ {print $2}' /etc/gtk-2.0/gtkrc)
+						gtk2Theme=$("${AWK}" -F'"' '/^gtk-fallback-theme-name/ {print $2}' /etc/gtk-2.0/gtkrc)
 					fi
 
 					if grep -q 'icon-theme' /etc/gtk-2.0/gtkrc; then
-						gtkIcons=$(awk -F'"' '/^icon-theme/ {print $2}' /etc/gtk-2.0/gtkrc)
+						gtkIcons=$("${AWK}" -F'"' '/^icon-theme/ {print $2}' /etc/gtk-2.0/gtkrc)
 					fi
 					if  grep -q 'gtk-fallback-icon-theme' /etc/gtk-2.0/gtkrc  && ! [ "x$gtkIcons" = "x" ]; then
-						gtkIcons=$(awk -F'"' '/^gtk-fallback-icon-theme/ {print $2}' /etc/gtk-2.0/gtkrc)
+						gtkIcons=$("${AWK}" -F'"' '/^gtk-fallback-icon-theme/ {print $2}' /etc/gtk-2.0/gtkrc)
 					fi
 
 					if grep -q 'font' /etc/gtk-2.0/gtkrc; then
-						gtkFont=$(awk -F'"' '/^gtk-font-name/ {print $2}' /etc/gtk-2.0/gtkrc)
+						gtkFont=$("${AWK}" -F'"' '/^gtk-font-name/ {print $2}' /etc/gtk-2.0/gtkrc)
 					fi
 				fi
 
 				# EXPERIMENTAL gtk3 Theme detection
 				if [[ "$gtk3Theme" = "Not Found" && -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
 					if grep -q 'gtk-theme-name' "$HOME/.config/gtk-3.0/settings.ini"; then
-						gtk3Theme=$(awk -F'=' '/^gtk-theme-name/ {print $2}' "$HOME/.config/gtk-3.0/settings.ini")
+						gtk3Theme=$("${AWK}" -F'=' '/^gtk-theme-name/ {print $2}' "$HOME/.config/gtk-3.0/settings.ini")
 					fi
 				fi
 
@@ -2921,7 +2936,7 @@ detectgtk () {
 
 				# ROX-Filer icon detect only
 				if [ -a "${XDG_CONFIG_HOME:-${HOME}/.config}/rox.sourceforge.net/ROX-Filer/Options" ]; then
-					gtkIcons=$(awk -F'[>,<]' '/icon_theme/ {print $3}' "${XDG_CONFIG_HOME:-${HOME}/.config}/rox.sourceforge.net/ROX-Filer/Options")
+					gtkIcons=$("${AWK}" -F'[>,<]' '/icon_theme/ {print $3}' "${XDG_CONFIG_HOME:-${HOME}/.config}/rox.sourceforge.net/ROX-Filer/Options")
 				fi
 
 				# E17 detection
@@ -2934,10 +2949,10 @@ detectgtk () {
 				# Background Detection (feh, nitrogen)
 				if [ "$background_detect" == "1" ]; then
 					if [ -a "$HOME/.fehbg" ]; then
-						gtkBackgroundFull=$(awk -F"'" '/feh --bg/{print $2}' "$HOME/.fehbg" 2>/dev/null)
-						gtkBackground=$(echo "$gtkBackgroundFull" | awk -F"/" '{print $NF}')
+						gtkBackgroundFull=$("${AWK}" -F"'" '/feh --bg/{print $2}' "$HOME/.fehbg" 2>/dev/null)
+						gtkBackground=$(echo "$gtkBackgroundFull" | "${AWK}" -F"/" '{print $NF}')
 					elif [ -a "${XDG_CONFIG_HOME:-${HOME}/.config}/nitrogen/bg-saved.cfg" ]; then
-						gtkBackground=$(awk -F"/" '/file=/ {print $NF}' "${XDG_CONFIG_HOME:-${HOME}/.config}/nitrogen/bg-saved.cfg")
+						gtkBackground=$("${AWK}" -F"/" '/file=/ {print $NF}' "${XDG_CONFIG_HOME:-${HOME}/.config}/nitrogen/bg-saved.cfg")
 					fi
 				fi
 
@@ -2972,7 +2987,7 @@ detectdroid () {
 		rom=$(getprop ro.build.display.id)
 	fi
 	baseband=$(getprop ro.baseband)
-	cpu=$(awk -F': ' '/^Processor/ {P=$2} /^Hardware/ {H=$2} END {print H != "" ? H : P}' /proc/cpuinfo)
+	cpu=$("${AWK}" -F': ' '/^Processor/ {P=$2} /^Hardware/ {H=$2} END {print H != "" ? H : P}' /proc/cpuinfo)
 }
 
 
@@ -6246,7 +6261,7 @@ asciiText () {
 		#n=${#fulloutput[*]}
 		for ((i=0; i<${#fulloutput[*]}; i++)); do
 			# echo "${out_array[@]}"
-			case $(awk 'BEGIN{srand();print int(rand()*(1000-1))+1 }') in
+			case $("${AWK}" 'BEGIN{srand();print int(rand()*(1000-1))+1 }') in
 				411|188|15|166|609)
 					f_size=${#fulloutput[*]}
 					o_size=${#out_array[*]}


### PR DESCRIPTION
Some embedded distributions (e.g. buildroot) may only provide mawk, without a symlink to awk.

At first glance, awk scripts to appear to work fine with either gawk or mawk.