### PR TITLE
Update requirements list in the documentation

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -23,7 +23,9 @@
 # to put forth suggestions/ideas. Thank you.
 
 # Requires: bash 4.0+
+#           bc
 # Optional dependencies: xorg-xdpyinfo (resoluton detection)
+#                        xorg-xprop (desktop environment detection)
 #                        scrot (screenshot taking)
 #                        curl (screenshot uploading)
 


### PR DESCRIPTION
This merge request is simply an update to the documentation to reflect that `bc` is a mandatory requirement. Also optionally screenFetch also uses `xprop` so it should also be documented as an optional dependency.