### PR TITLE
Fix bad conditions on if statements that were causing false DE detection

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -2104,7 +2104,7 @@ detectde () {
 				esac
 			fi
 
-			if [ -n "$DE" ]; then
+			if [[ ${DE} == "Not Present" ]]; then
 				# classic fallbacks
 				if [ -n "$KDE_FULL_SESSION" ]; then
 					DE="KDE"
@@ -2126,7 +2126,7 @@ detectde () {
 				fi
 			fi
 
-			if [[ -z "$DE" || "$DE" = "Not Present" ]]; then
+			if [[ "$DE" = "Not Present" ]]; then
 				# fallback to checking $DESKTOP_SESSION
 				local _DESKTOP_SESSION=
 				if [[ ${BASH_VERSINFO[0]} -ge 4 ]]; then
@@ -2169,7 +2169,7 @@ detectde () {
 				esac
 			fi
 
-			if [ -n "$DE" ]; then
+			if [[ ${DE} == "Not Present" ]]; then
 				# fallback to checking $GDMSESSION
 				case "${GDMSESSION,,}" in
 					'lumina'*)


### PR DESCRIPTION
There are two instances of the condition:
if [ -n "$DE" ]; then

I think if statements with this condition were ALWAYS running, because at the beginning of detectde () $DE gets initialized to "Not Present".

if [[ -z "$DE" || "$DE" = "Not Present" ]]; then

There was one instance of this, which I believe is supposed to have a "==" vs "=". The first part of the condition is also NEVER false, since $DE gets initialized to "Not Present", as mentioned before, so I just removed it.

Fixes #782 (and possibly others)