### PR TITLE
update ubuntu codename

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -185,6 +185,7 @@ ubuntu_codenames=(
 		'LTS (Jammy Jellyfish)'		# 22.04
 		'(Lunar Lobster)'		# 23.04
 		'(Mantic Minotaur)'		# 23.10
+		'LTS (Noble Numbat)'		# 24.04
 )
 
 # Screenshot Settings


### PR DESCRIPTION
update ubuntu codename for new LTS-version 24.04 (https://wiki.ubuntu.com/Releases)