### PR TITLE
rft(snap): Conditionally check for snap packages

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1526,14 +1526,18 @@ detectpkgs () {
 			fi
 		;;
 	esac
-	if [[ "${OSTYPE}" =~ "linux" && -z "${wsl}" ]] && snap list >/dev/null 2>&1; then
-		offset=1
-		snappkgs=$(($(snap list 2>/dev/null | wc -l) - offset))
-		if [ $snappkgs -lt 0 ]; then
-			snappkgs=0
-		fi
-		pkgs=$((pkgs + snappkgs))
-	fi
+  # Check if snapd is even running on the system otherwise the client keeps trying
+  # to connect to it and ultimately fails
+  if [[ -e /run/snapd.socket ]]; then
+    if [[ "${OSTYPE}" =~ "linux" && -z "${wsl}" ]] && snap list >/dev/null 2>&1; then
+	    offset=1
+	    snappkgs=$(($(snap list 2>/dev/null | wc -l) - offset))
+	    if [ $snappkgs -lt 0 ]; then
+		      snappkgs=0
+	    fi
+	    pkgs=$((pkgs + snappkgs))
+	  fi
+  fi
 	verboseOut "Finding current package count...found as '$pkgs'"
 }
 


### PR DESCRIPTION
* In the event that the snapd service is not running, the snap client can spend a large amount of time trying to connect to it and ultimately failing. The expectation is that since snap comes already installed in several linux distros that the socket is placed in the same place.

```bash
 $ # with the check
 $ time ./screenfetch-dev
  real    0m0.680s
  user    0m0.389s
  sys     0m0.260s

 $ # without the check
 $ time screenfetch
  real    2m0.908s
  user    0m0.632s
  sys     0m0.501s
```