### PR TITLE
fix(linewrap): Linewrap doesn't require an additional argument

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -489,7 +489,7 @@ if ! command -v "${AWK}" > /dev/null; then
 fi
 
 # Parse the rest of the flags (some of these functions require awk)
-while getopts ":hsu:evVEnLNtlS:A:D:o:c:d:pa:w:C:" flags; do
+while getopts ":hsu:evVEnLNtlS:A:D:o:c:d:pa:C:w" flags; do
 	case $flags in
 		h) displayHelp; exit 0 ;;
 		s) screenshot='1' ;;


### PR DESCRIPTION
Given `w` is simply a flag not a option in the sense that it requires an additional argument. `getopts` opts suffixed with a `:` require an additional arg.[1]

```quote
If a character is
followed by a <colon>, the option shall be expected to
have an argument, which should be supplied as a
separate argument.
```

[1]: https://man7.org/linux/man-pages/man1/getopts.1p.html