### PR TITLE
change CPU format

### DIFF
--- a/screenfetch-dev
+++ b/screenfetch-dev
@@ -1641,14 +1641,14 @@ detectcpu () {
 		fi
 	fi
 	if [[ "${cpun}" -gt "1" ]]; then
-		cpun="${cpun}x "
+		cpun="${cpun}x"
 	else
 		cpun=""
 	fi
 	if [ -z "$cpufreq" ]; then
 		cpu="${cpun}${cpu}"
 	else
-		cpu="$cpu @ ${cpun}${cpufreq}"
+		cpu="$cpu (${cpun}) @ ${cpufreq}"
 	fi
 	if [ -d '/sys/class/hwmon/' ]; then
 		for dir in /sys/class/hwmon/* ; do


### PR DESCRIPTION
[`AMD Ryzen Threadripper 7980X`](https://www.cpu-monkey.com/en/cpu-amd_ryzen_threadripper_7980x)  64C 128T @ 3.20 GHz

```
CPU: Intel Xeon Gold 6146 (2x) @ 3.0GHz
```